### PR TITLE
Add sample for mutex workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ TEST_DIRS=./cmd/samples/cron \
 	./cmd/samples/recipes/helloworld \
 	./cmd/samples/recipes/cancelactivity \
 	./cmd/samples/recipes/pickfirst \
+	./cmd/samples/recipes/mutex \
 	./cmd/samples/recipes/retryactivity \
 	./cmd/samples/recipes/splitmerge \
 	./cmd/samples/recipes/timer \
@@ -84,6 +85,9 @@ greetings: dep-ensured $(ALL_SRC)
 
 pickfirst: dep-ensured $(ALL_SRC)
 	go build -i -o bin/pickfirst cmd/samples/recipes/pickfirst/*.go
+
+mutex: dep-ensured $(ALL_SRC)
+	go build -i -o bin/mutex cmd/samples/recipes/mutex/*.go
 
 retryactivity: dep-ensured $(ALL_SRC)
 	go build -i -o bin/retryactivity cmd/samples/recipes/retryactivity/*.go
@@ -134,6 +138,7 @@ bins: helloworld \
 	dynamic \
 	greetings \
 	pickfirst \
+	mutex \
 	retryactivity \
 	splitmerge \
 	searchattributes \

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Run the multi choice workflow
 ./bin/pickfirst -m trigger
 ```
 
+#### mutex
+```
+./bin/mutex -m worker
+```
+```
+./bin/mutex -m trigger
+```
+
 #### retryactivity
 ```
 ./bin/retryactivity -m worker

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -109,6 +109,26 @@ func (h *SampleHelper) StartWorkflowWithCtx(ctx context.Context, options client.
 	}
 }
 
+// SignalWithStartWorkflowWithCtx signals workflow and starts it if it's not yet started
+func (h *SampleHelper) SignalWithStartWorkflowWithCtx(ctx context.Context, workflowID string, signalName string, signalArg interface{},
+	options client.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) *workflow.Execution {
+	workflowClient, err := h.Builder.BuildCadenceClient()
+	if err != nil {
+		h.Logger.Error("Failed to build cadence client.", zap.Error(err))
+		panic(err)
+	}
+
+	we, err := workflowClient.SignalWithStartWorkflow(ctx, workflowID, signalName, signalArg, options, workflow, workflowArgs...)
+	if err != nil {
+		h.Logger.Error("Failed to signal with start workflow", zap.Error(err))
+		panic("Failed to signal with start workflow.")
+
+	} else {
+		h.Logger.Info("Signaled and started Workflow", zap.String("WorkflowID", we.ID), zap.String("RunID", we.RunID))
+	}
+	return we
+}
+
 // StartWorkers starts workflow worker and activity worker based on configured options.
 func (h *SampleHelper) StartWorkers(domainName, groupName string, options worker.Options) {
 	worker := worker.New(h.Service, domainName, groupName, options)

--- a/cmd/samples/recipes/mutex/main.go
+++ b/cmd/samples/recipes/mutex/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/pborman/uuid"
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/worker"
+)
+
+const (
+	// ApplicationName is the task list for this sample
+	ApplicationName = "mutexExample"
+
+	_sampleHelperContextKey = "sampleHelper"
+)
+
+// This needs to be done as part of a bootstrap step when the process starts.
+// The workers are supposed to be long running.
+func startWorkers(h *common.SampleHelper) {
+	// Configure worker options.
+	workerOptions := worker.Options{
+		MetricsScope: h.Scope,
+		Logger:       h.Logger,
+		BackgroundActivityContext: context.WithValue(context.Background(), _sampleHelperContextKey, h),
+	}
+
+	// Start Worker.
+	worker := worker.New(
+		h.Service,
+		h.Config.DomainName,
+		ApplicationName,
+		workerOptions)
+	err := worker.Start()
+	if err != nil {
+		panic("Failed to start workers")
+	}
+}
+
+// startTwoWorkflows starts two workflows that operate on the same recourceID
+func startTwoWorkflows(h *common.SampleHelper) {
+	resourceID := uuid.New()
+	h.StartWorkflow(client.StartWorkflowOptions{
+		ID:                              "SampleWorkflowWithMutex_" + uuid.New(),
+		TaskList:                        ApplicationName,
+		ExecutionStartToCloseTimeout:    10 * time.Minute,
+		DecisionTaskStartToCloseTimeout: time.Minute,
+	},
+		SampleWorkflowWithMutex,
+		resourceID)
+	h.StartWorkflow(client.StartWorkflowOptions{
+		ID:                              "SampleWorkflowWithMutex_" + uuid.New(),
+		TaskList:                        ApplicationName,
+		ExecutionStartToCloseTimeout:    10 * time.Minute,
+		DecisionTaskStartToCloseTimeout: time.Minute,
+	},
+		SampleWorkflowWithMutex,
+		resourceID)
+}
+
+func main() {
+	var mode string
+	flag.StringVar(&mode, "m", "trigger", "Mode is worker or trigger.")
+	flag.Parse()
+
+	var h common.SampleHelper
+	h.SetupServiceConfig()
+
+	switch mode {
+	case "worker":
+		startWorkers(&h)
+
+		// The workers are supposed to be long running process that should not exit.
+		// Use select{} to block indefinitely for samples, you can quit by CMD+C.
+		select {}
+	case "trigger":
+		startTwoWorkflows(&h)
+	}
+}

--- a/cmd/samples/recipes/mutex/mutex_workflow.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+func init() {
+	activity.Register(SignalWithStartMutexWorkflowActivity)
+	workflow.Register(MutexWorkflow)
+	workflow.Register(SampleWorkflowWithMutex)
+}
+
+const (
+	// AcquireLockSignalName signal channel name for lock acquisition
+	AcquireLockSignalName = "acquire-lock-event"
+	// RequestLockSignalName channel name for request lock
+	RequestLockSignalName = "request-lock-event"
+)
+
+// UnlockFunc ...
+type UnlockFunc func() error
+
+// Mutex - cadence mutex
+type Mutex struct {
+	currentWorkflowID string
+	lockNamespace     string
+}
+
+// NewMutex initializes cadence mutex
+func NewMutex(currentWorkflowID string, lockNamespace string) *Mutex {
+	return &Mutex{
+		currentWorkflowID: currentWorkflowID,
+		lockNamespace:     lockNamespace,
+	}
+}
+
+// Lock - locks mutex
+func (s *Mutex) Lock(ctx workflow.Context,
+	resourceID string, unlockTimeout time.Duration) (UnlockFunc, error) {
+
+	activityCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
+		ScheduleToCloseTimeout: time.Minute * 1,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:          time.Second,
+			BackoffCoefficient:       2.0,
+			MaximumInterval:          time.Minute,
+			ExpirationInterval:       time.Minute * 10,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"bad-error"},
+		},
+	})
+
+	var releaseLockChannelName string
+	var execution workflow.Execution
+	err := workflow.ExecuteLocalActivity(activityCtx,
+		SignalWithStartMutexWorkflowActivity, s.lockNamespace,
+		resourceID, s.currentWorkflowID, unlockTimeout).Get(ctx, &execution)
+	if err != nil {
+		return nil, err
+	}
+	workflow.GetSignalChannel(ctx, AcquireLockSignalName).
+		Receive(ctx, &releaseLockChannelName)
+
+	unlockFunc := func() error {
+		return workflow.SignalExternalWorkflow(ctx, execution.ID, execution.RunID,
+			releaseLockChannelName, "releaseLock").Get(ctx, nil)
+	}
+	return unlockFunc, nil
+}
+
+// MutexWorkflow used for locking a resource
+func MutexWorkflow(
+	ctx workflow.Context,
+	namespace string,
+	resourceID string,
+	unlockTimeout time.Duration,
+) error {
+	currentWorkflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	if currentWorkflowID == "default-test-workflow-id" {
+		// unit testing hack, see https://github.com/uber-go/cadence-client/issues/663
+		workflow.Sleep(ctx, 10*time.Millisecond)
+	}
+	logger := workflow.GetLogger(ctx).With(zap.String("currentWorkflowID", currentWorkflowID))
+	logger.Info("started")
+	var ack string
+	requestLockCh := workflow.GetSignalChannel(ctx, RequestLockSignalName)
+	for {
+		var senderWorkflowID string
+		if !requestLockCh.ReceiveAsync(&senderWorkflowID) {
+			logger.Info("no more signals")
+			break
+		}
+		var releaseLockChannelName string
+		_ = workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
+			return _generateUnlockChannelName(senderWorkflowID)
+		}).Get(&releaseLockChannelName)
+		logger := logger.With(zap.String("releaseLockChannelName", releaseLockChannelName))
+		logger.Info("generated release lock channel name")
+		// Send release lock channel name back to a senderWorkflowID, so that it can
+		// release the lock using release lock channel name
+		err := workflow.SignalExternalWorkflow(ctx, senderWorkflowID, "",
+			AcquireLockSignalName, releaseLockChannelName).Get(ctx, nil)
+		if err != nil {
+			// .Get(ctx, nil) blocks until the signal is sent.
+			// If the senderWorkflowID is closed (terminated/canceled/timeouted/completed/etc), this would return error.
+			// In this case we release the lock immediately instead of failing the mutex workflow.
+			// Mutex workflow failing would lead to all workflows that have sent requestLock will be waiting.
+			continue
+		}
+		logger.With(zap.Error(err)).Info("signaled external workflow")
+		selector := workflow.NewSelector(ctx)
+		selector.AddFuture(workflow.NewTimer(ctx, unlockTimeout), func(f workflow.Future) {
+			logger.Info("unlockTimeout exceeded")
+		})
+		selector.AddReceive(workflow.GetSignalChannel(ctx, releaseLockChannelName), func(c workflow.Channel, more bool) {
+			c.Receive(ctx, &ack)
+			logger.Info("release signal received")
+		})
+		selector.Select(ctx)
+	}
+	return nil
+}
+
+// SignalWithStartMutexWorkflowActivity ...
+func SignalWithStartMutexWorkflowActivity(
+	ctx context.Context,
+	namespace string,
+	resourceID string,
+	senderWorkflowID string,
+	unlockTimeout time.Duration,
+) (*workflow.Execution, error) {
+
+	h := ctx.Value(_sampleHelperContextKey).(*common.SampleHelper)
+	workflowID := fmt.Sprintf(
+		"%s:%s:%s",
+		"mutex",
+		namespace,
+		resourceID,
+	)
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                              workflowID,
+		TaskList:                        ApplicationName,
+		ExecutionStartToCloseTimeout:    time.Hour,
+		DecisionTaskStartToCloseTimeout: time.Hour,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:          time.Second,
+			BackoffCoefficient:       2.0,
+			MaximumInterval:          time.Minute,
+			ExpirationInterval:       time.Minute * 10,
+			MaximumAttempts:          5,
+			NonRetriableErrorReasons: []string{"bad-error"},
+		},
+		WorkflowIDReusePolicy: client.WorkflowIDReusePolicyAllowDuplicate,
+	}
+	we := h.SignalWithStartWorkflowWithCtx(
+		ctx, workflowID, RequestLockSignalName, senderWorkflowID,
+		workflowOptions, MutexWorkflow, namespace, resourceID, unlockTimeout)
+	return we, nil
+}
+
+// _generateUnlockChannelName generates release lock channel name
+func _generateUnlockChannelName(senderWorkflowID string) string {
+	return fmt.Sprintf("unlock-event-%s", senderWorkflowID)
+}
+
+// MockMutexLock stubs cadence mutex.Lock call
+func MockMutexLock(env *testsuite.TestWorkflowEnvironment, resourceID string, mockError error) {
+	mockExecution := &workflow.Execution{ID: "mockID", RunID: "mockRunID"}
+	env.OnActivity(SignalWithStartMutexWorkflowActivity,
+		mock.Anything, mock.Anything, resourceID, mock.Anything, mock.Anything).
+		Return(mockExecution, mockError)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(AcquireLockSignalName, "mockReleaseLockChannelName")
+	}, time.Millisecond*0)
+	if mockError == nil {
+		env.OnSignalExternalWorkflow(mock.Anything, mock.Anything, mockExecution.RunID,
+			mock.Anything, mock.Anything).Return(nil)
+	}
+}
+
+func SampleWorkflowWithMutex(
+	ctx workflow.Context,
+	resourceID string,
+) error {
+	currentWorkflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	logger := workflow.GetLogger(ctx).
+		With(zap.String("currentWorkflowID", currentWorkflowID)).
+		With(zap.String("resourceID", resourceID))
+	logger.Info("started")
+
+	mutex := NewMutex(currentWorkflowID, "TestUseCase")
+	unlockFunc, err := mutex.Lock(ctx, resourceID, 10*time.Minute)
+	if err != nil {
+		return err
+	}
+	logger.Info("resource locked")
+
+	// emulate long running process
+	logger.Info("critical operation started")
+	workflow.Sleep(ctx, 10*time.Second)
+	logger.Info("critical operation finished")
+
+	unlockFunc()
+
+	logger.Info("finished")
+	return nil
+}

--- a/cmd/samples/recipes/mutex/mutex_workflow.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow.go
@@ -115,6 +115,7 @@ func MutexWorkflow(
 			// If the senderWorkflowID is closed (terminated/canceled/timeouted/completed/etc), this would return error.
 			// In this case we release the lock immediately instead of failing the mutex workflow.
 			// Mutex workflow failing would lead to all workflows that have sent requestLock will be waiting.
+			logger.With(zap.Error(err)).Info("SignalExternalWorkflow error")
 			continue
 		}
 		logger.With(zap.Error(err)).Info("signaled external workflow")

--- a/cmd/samples/recipes/mutex/mutex_workflow.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow.go
@@ -52,12 +52,11 @@ func (s *Mutex) Lock(ctx workflow.Context,
 	activityCtx := workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{
 		ScheduleToCloseTimeout: time.Minute * 1,
 		RetryPolicy: &cadence.RetryPolicy{
-			InitialInterval:          time.Second,
-			BackoffCoefficient:       2.0,
-			MaximumInterval:          time.Minute,
-			ExpirationInterval:       time.Minute * 10,
-			MaximumAttempts:          5,
-			NonRetriableErrorReasons: []string{"bad-error"},
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute,
+			ExpirationInterval: time.Minute * 10,
+			MaximumAttempts:    5,
 		},
 	})
 
@@ -154,12 +153,11 @@ func SignalWithStartMutexWorkflowActivity(
 		ExecutionStartToCloseTimeout:    time.Hour,
 		DecisionTaskStartToCloseTimeout: time.Hour,
 		RetryPolicy: &cadence.RetryPolicy{
-			InitialInterval:          time.Second,
-			BackoffCoefficient:       2.0,
-			MaximumInterval:          time.Minute,
-			ExpirationInterval:       time.Minute * 10,
-			MaximumAttempts:          5,
-			NonRetriableErrorReasons: []string{"bad-error"},
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute,
+			ExpirationInterval: time.Minute * 10,
+			MaximumAttempts:    5,
 		},
 		WorkflowIDReusePolicy: client.WorkflowIDReusePolicyAllowDuplicate,
 	}

--- a/cmd/samples/recipes/mutex/mutex_workflow_test.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+
+	var h common.SampleHelper
+	s.env.SetWorkerOptions(worker.Options{
+		BackgroundActivityContext: context.WithValue(context.Background(), _sampleHelperContextKey, h),
+	})
+}
+
+func (s *UnitTestSuite) Test_Workflow_Success() {
+	env := s.NewTestWorkflowEnvironment()
+	mockResourceID := "mockResourceID"
+	MockMutexLock(env, mockResourceID, nil)
+	env.ExecuteWorkflow(SampleWorkflowWithMutex, mockResourceID)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_Workflow_Error() {
+	env := s.NewTestWorkflowEnvironment()
+	mockResourceID := "mockResourceID"
+	MockMutexLock(env, mockResourceID, errors.New("bad-error"))
+	env.ExecuteWorkflow(SampleWorkflowWithMutex, mockResourceID)
+
+	s.True(env.IsWorkflowCompleted())
+	s.EqualError(env.GetWorkflowError(), "bad-error")
+	env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_MutexWorkflow_Success() {
+	mockNamespace := "mockNamespace"
+	mockResourceID := "mockResourceID"
+	mockUnlockTimeout := 10 * time.Minute
+	mockSenderWorkflowID := "mockSenderWorkflowID"
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(RequestLockSignalName, mockSenderWorkflowID)
+	}, time.Millisecond*0)
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow("unlock-event-mockSenderWorkflowID", "releaseLock")
+	}, time.Millisecond*0)
+	s.env.OnSignalExternalWorkflow(mock.Anything, mockSenderWorkflowID, "",
+		AcquireLockSignalName, mock.Anything).Return(nil)
+
+	s.env.ExecuteWorkflow(
+		MutexWorkflow,
+		mockNamespace,
+		mockResourceID,
+		mockUnlockTimeout,
+	)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}
+
+func (s *UnitTestSuite) Test_MutexWorkflow_TimeoutSuccess() {
+	mockNamespace := "mockNamespace"
+	mockResourceID := "mockResourceID"
+	mockUnlockTimeout := 10 * time.Minute
+	mockSenderWorkflowID := "mockSenderWorkflowID"
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(RequestLockSignalName, mockSenderWorkflowID)
+	}, time.Millisecond*0)
+	s.env.OnSignalExternalWorkflow(mock.Anything, mockSenderWorkflowID, "",
+		AcquireLockSignalName, mock.Anything).Return(nil)
+
+	s.env.ExecuteWorkflow(
+		MutexWorkflow,
+		mockNamespace,
+		mockResourceID,
+		mockUnlockTimeout,
+	)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+}


### PR DESCRIPTION
MutexWorkflow can be used for locking the resource when two or more cadence workflows try to perform operation concurrently on the same resouceID