### PR TITLE
Fix unit tests

### DIFF
--- a/cmd/samples/cron/cron_workflow_test.go
+++ b/cmd/samples/cron/cron_workflow_test.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"go.uber.org/cadence/activity"
-	"go.uber.org/cadence/encoded"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/workflow"
 )
@@ -16,10 +16,22 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleCronWorkflow)
+	s.env.RegisterActivity(sampleCronActivity)
+}
+
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
 }
 
 func (s *UnitTestSuite) Test_CronWorkflow() {
@@ -36,14 +48,12 @@ func (s *UnitTestSuite) Test_CronWorkflow() {
 		s.False(cronFuture.IsReady())
 		return nil
 	}
+	s.env.RegisterWorkflow(testWorkflow)
 
-	workflow.Register(testWorkflow)
-
-	env := s.NewTestWorkflowEnvironment()
-	env.OnActivity(sampleCronActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
+	s.env.OnActivity(sampleCronActivity, mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(3)
 
 	var startTimeList, endTimeList []time.Time
-	env.SetOnActivityStartedListener(func(activityInfo *activity.Info, ctx context.Context, args encoded.Values) {
+	s.env.SetOnActivityStartedListener(func(activityInfo *activity.Info, ctx context.Context, args encoded.Values) {
 		var startTime, endTime time.Time
 		err := args.Get(&startTime, &endTime)
 		s.NoError(err)
@@ -53,14 +63,13 @@ func (s *UnitTestSuite) Test_CronWorkflow() {
 	})
 
 	startTime, _ := time.Parse(time.RFC3339, "2018-12-20T16:30:00-80:00")
-	env.SetStartTime(startTime)
+	s.env.SetStartTime(startTime)
 
-	env.ExecuteWorkflow(testWorkflow)
+	s.env.ExecuteWorkflow(testWorkflow)
 
-	s.True(env.IsWorkflowCompleted())
-	err := env.GetWorkflowError()
+	s.True(s.env.IsWorkflowCompleted())
+	err := s.env.GetWorkflowError()
 	s.NoError(err)
-	env.AssertExpectations(s.T())
 
 	s.Equal(3, len(startTimeList))
 	s.True(startTimeList[0].Equal(time.Time{}))

--- a/cmd/samples/cron/main.go
+++ b/cmd/samples/cron/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 const (

--- a/cmd/samples/dsl/main.go
+++ b/cmd/samples/dsl/main.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
 	"gopkg.in/yaml.v2"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/expense/main.go
+++ b/cmd/samples/expense/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/expense/server/dummy.go
+++ b/cmd/samples/expense/server/dummy.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 /**
@@ -38,7 +39,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
 
 	fmt.Println("Starting dummy server...")
 	http.HandleFunc("/", listHandler)

--- a/cmd/samples/fileprocessing/main.go
+++ b/cmd/samples/fileprocessing/main.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
-
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/fileprocessing/main.go
+++ b/cmd/samples/fileprocessing/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/fileprocessing/workflow_test.go
+++ b/cmd/samples/fileprocessing/workflow_test.go
@@ -14,10 +14,30 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleFileProcessingWorkflow)
+	s.env.RegisterActivityWithOptions(downloadFileActivity, activity.RegisterOptions{
+		Name: downloadFileActivityName,
+	})
+	s.env.RegisterActivityWithOptions(processFileActivity, activity.RegisterOptions{
+		Name: processFileActivityName,
+	})
+	s.env.RegisterActivityWithOptions(uploadFileActivity, activity.RegisterOptions{
+		Name: uploadFileActivityName,
+	})
+}
+
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
 }
 
 func (s *UnitTestSuite) Test_SampleFileProcessingWorkflow() {
@@ -29,8 +49,7 @@ func (s *UnitTestSuite) Test_SampleFileProcessingWorkflow() {
 	}
 
 	var activityCalled []string
-	env := s.NewTestWorkflowEnvironment()
-	env.SetOnActivityStartedListener(func(activityInfo *activity.Info, ctx context.Context, args encoded.Values) {
+	s.env.SetOnActivityStartedListener(func(activityInfo *activity.Info, ctx context.Context, args encoded.Values) {
 		activityType := activityInfo.ActivityType.Name
 		if strings.HasPrefix(activityType, "internalSession") {
 			return
@@ -53,9 +72,9 @@ func (s *UnitTestSuite) Test_SampleFileProcessingWorkflow() {
 			panic("unexpected activity call")
 		}
 	})
-	env.ExecuteWorkflow(sampleFileProcessingWorkflow, fileID)
+	s.env.ExecuteWorkflow(sampleFileProcessingWorkflow, fileID)
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 	s.Equal(expectedCall, activityCalled)
 }

--- a/cmd/samples/pageflow/main.go
+++ b/cmd/samples/pageflow/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"time"
+
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
 	"go.uber.org/cadence/workflow"
-	"time"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/pageflow/workflow.go
+++ b/cmd/samples/pageflow/workflow.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
+	"time"
+
 	"github.com/pborman/uuid"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-	"time"
 )
 
 /**
@@ -17,32 +18,32 @@ import (
 const (
 	// ApplicationName is the task list for this sample
 	ApplicationName = "pageflow"
-	SignalName = "trigger-signal"
-	QueryName = "state"
+	SignalName      = "trigger-signal"
+	QueryName       = "state"
 )
 
 type State string
 
 const (
-	Initialized State = "initialized"
-	Received = "received"
-	Created = "created"
-	SubmissionReceived = "submission-received"
-	Submitted = "submitted"
-	Approved = "approved"
-	Rejected = "rejected"
-	Withdrawn = "withdrawn"
+	Initialized        State = "initialized"
+	Received                 = "received"
+	Created                  = "created"
+	SubmissionReceived       = "submission-received"
+	Submitted                = "submitted"
+	Approved                 = "approved"
+	Rejected                 = "rejected"
+	Withdrawn                = "withdrawn"
 )
 
 type Action string
 
 const (
-	Create Action = "create"
-	Save = "save"
-	Submit = "submit"
-	Approve = "approve"
-	Reject = "reject"
-	Withdraw = "withdraw"
+	Create   Action = "create"
+	Save            = "save"
+	Submit          = "submit"
+	Approve         = "approve"
+	Reject          = "reject"
+	Withdraw        = "withdraw"
 )
 
 type signalPayload struct {
@@ -61,7 +62,7 @@ func pageWorkflow(ctx workflow.Context) (State, error) {
 
 	ao := workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Second,
-		StartToCloseTimeout:    10*time.Second,
+		StartToCloseTimeout:    10 * time.Second,
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 

--- a/cmd/samples/pso/position.go
+++ b/cmd/samples/pso/position.go
@@ -1,8 +1,8 @@
 package main
 
-import "math/rand"
-
-//import "go.uber.org/cadence/workflow"
+import (
+	"math/rand"
+)
 
 type Vector []float64
 

--- a/cmd/samples/pso/workflow.go
+++ b/cmd/samples/pso/workflow.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pborman/uuid"
 	"go.uber.org/cadence"
-
 	"go.uber.org/cadence/workflow"
 )
 

--- a/cmd/samples/pso/workflow_test.go
+++ b/cmd/samples/pso/workflow_test.go
@@ -4,19 +4,25 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/cadence/workflow"
-
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/worker"
+	"go.uber.org/cadence/workflow"
 )
 
 func Test_Workflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(samplePSOWorkflow)
+	env.RegisterWorkflow(samplePSOChildWorkflow)
+	env.RegisterActivityWithOptions(initParticleActivity, activity.RegisterOptions{
+		Name: initParticleActivityName,
+	})
+	env.RegisterActivityWithOptions(updateParticleActivity, activity.RegisterOptions{
+		Name: updateParticleActivityName,
+	})
 
 	var activityCalled []string
 

--- a/cmd/samples/recipes/branch/branch_workflow.go
+++ b/cmd/samples/recipes/branch/branch_workflow.go
@@ -20,6 +20,7 @@ const (
 
 // sampleBranchWorkflow workflow decider
 func sampleBranchWorkflow(ctx workflow.Context) error {
+	fmt.Println("executed workflow!!!")
 	var futures []workflow.Future
 	// starts activities in parallel
 	ao := workflow.ActivityOptions{
@@ -37,7 +38,9 @@ func sampleBranchWorkflow(ctx workflow.Context) error {
 
 	// wait until all futures are done
 	for _, future := range futures {
-		future.Get(ctx, nil)
+		if err := future.Get(ctx, nil); err != nil {
+			return err
+		}
 	}
 
 	workflow.GetLogger(ctx).Info("Workflow completed.")

--- a/cmd/samples/recipes/branch/branch_workflow.go
+++ b/cmd/samples/recipes/branch/branch_workflow.go
@@ -20,7 +20,6 @@ const (
 
 // sampleBranchWorkflow workflow decider
 func sampleBranchWorkflow(ctx workflow.Context) error {
-	fmt.Println("executed workflow!!!")
 	var futures []workflow.Future
 	// starts activities in parallel
 	ao := workflow.ActivityOptions{

--- a/cmd/samples/recipes/branch/main.go
+++ b/cmd/samples/recipes/branch/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/recipes/branch/parallel_workflow.go
+++ b/cmd/samples/recipes/branch/parallel_workflow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"time"
 
 	"go.uber.org/cadence/workflow"
@@ -27,25 +28,39 @@ func sampleParallelWorkflow(ctx workflow.Context) error {
 		err := workflow.ExecuteActivity(ctx, sampleActivity, "branch1.1").Get(ctx, nil)
 		if err != nil {
 			logger.Error("Activity failed", zap.Error(err))
+			waitChannel.Send(ctx, err.Error())
+			return
 		}
 		err = workflow.ExecuteActivity(ctx, sampleActivity, "branch1.2").Get(ctx, nil)
 		if err != nil {
 			logger.Error("Activity failed", zap.Error(err))
+			waitChannel.Send(ctx, err.Error())
+			return
 		}
-		waitChannel.Send(ctx, true)
+		waitChannel.Send(ctx, "")
 	})
 
 	workflow.Go(ctx, func(ctx workflow.Context) {
 		err := workflow.ExecuteActivity(ctx, sampleActivity, "branch2").Get(ctx, nil)
 		if err != nil {
 			logger.Error("Activity failed", zap.Error(err))
+			waitChannel.Send(ctx, err.Error())
+			return
 		}
-		waitChannel.Send(ctx, true)
+		waitChannel.Send(ctx, "")
 	})
 
 	// wait for both of the coroutinue to complete.
-	waitChannel.Receive(ctx, nil)
-	waitChannel.Receive(ctx, nil)
+	var errMsg string
+	for i := 0; i != 2; i++ {
+		waitChannel.Receive(ctx, &errMsg)
+		if errMsg != "" {
+			err := errors.New(errMsg)
+			logger.Error("Coroutine failed", zap.Error(err))
+			return err
+		}
+	}
+
 	logger.Info("Workflow completed.")
 	return nil
 }

--- a/cmd/samples/recipes/branch/workflow_test.go
+++ b/cmd/samples/recipes/branch/workflow_test.go
@@ -10,24 +10,35 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
 }
 
-func (s *UnitTestSuite) Test_BranchWorkflow() {
-	env := s.NewTestWorkflowEnvironment()
-	env.ExecuteWorkflow(sampleBranchWorkflow)
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleBranchWorkflow)
+	s.env.RegisterWorkflow(sampleParallelWorkflow)
+	s.env.RegisterActivity(sampleActivity)
+}
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_BranchWorkflow() {
+	s.env.ExecuteWorkflow(sampleBranchWorkflow)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }
 
 func (s *UnitTestSuite) Test_ParallelWorkflow() {
-	env := s.NewTestWorkflowEnvironment()
-	env.ExecuteWorkflow(sampleParallelWorkflow)
+	s.env.ExecuteWorkflow(sampleParallelWorkflow)
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }

--- a/cmd/samples/recipes/childworkflow/main.go
+++ b/cmd/samples/recipes/childworkflow/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/recipes/choice/multi_choice_workflow.go
+++ b/cmd/samples/recipes/choice/multi_choice_workflow.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"

--- a/cmd/samples/recipes/choice/workflow_test.go
+++ b/cmd/samples/recipes/choice/workflow_test.go
@@ -10,24 +10,40 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
 }
 
-func (s *UnitTestSuite) Test_ExclusiveChoiceWorkflow() {
-	env := s.NewTestWorkflowEnvironment()
-	env.ExecuteWorkflow(exclusiveChoiceWorkflow)
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(exclusiveChoiceWorkflow)
+	s.env.RegisterWorkflow(multiChoiceWorkflow)
+	s.env.RegisterActivity(getOrderActivity)
+	s.env.RegisterActivity(orderAppleActivity)
+	s.env.RegisterActivity(orderBananaActivity)
+	s.env.RegisterActivity(orderCherryActivity)
+	s.env.RegisterActivity(orderOrangeActivity)
+	s.env.RegisterActivity(getBasketOrderActivity)
+}
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_ExclusiveChoiceWorkflow() {
+	s.env.ExecuteWorkflow(exclusiveChoiceWorkflow)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }
 
 func (s *UnitTestSuite) Test_MultiChoiceWorkflow() {
-	env := s.NewTestWorkflowEnvironment()
-	env.ExecuteWorkflow(multiChoiceWorkflow)
+	s.env.ExecuteWorkflow(multiChoiceWorkflow)
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }

--- a/cmd/samples/recipes/ctxpropagation/main.go
+++ b/cmd/samples/recipes/ctxpropagation/main.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
 	"go.uber.org/cadence/workflow"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/recipes/ctxpropagation/workflow_test.go
+++ b/cmd/samples/recipes/ctxpropagation/workflow_test.go
@@ -16,7 +16,8 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
-	env *testsuite.TestWorkflowEnvironment
+
+	env    *testsuite.TestWorkflowEnvironment
 	header *shared.Header
 }
 
@@ -38,6 +39,8 @@ func (s *UnitTestSuite) SetupTest() {
 	}
 
 	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleCtxPropWorkflow)
+	s.env.RegisterActivityWithOptions(sampleActivity, activity.RegisterOptions{Name: "sampleActivity"})
 	s.env.SetWorkerOptions(workerOptions)
 }
 
@@ -65,7 +68,6 @@ func (s *UnitTestSuite) Test_CtxPropWorkflow() {
 			panic("there was a problem propagating Values, the value field doesn't match")
 		}
 	})
-	s.env.RegisterActivityWithOptions(sampleActivity, activity.RegisterOptions{Name: "sampleActivity"})
 	s.env.ExecuteWorkflow(sampleCtxPropWorkflow)
 
 	s.True(s.env.IsWorkflowCompleted())

--- a/cmd/samples/recipes/dynamic/main.go
+++ b/cmd/samples/recipes/dynamic/main.go
@@ -43,9 +43,9 @@ func main() {
 	switch mode {
 	case "worker":
 		h.RegisterWorkflow(sampleGreetingsWorkflow)
-		h.RegisterActivity(getGreetingActivity)
-		h.RegisterActivity(getNameActivity)
-		h.RegisterActivity(sayGreetingActivity)
+		h.RegisterActivityWithAlias(getGreetingActivity, getGreetingActivityName)
+		h.RegisterActivityWithAlias(getNameActivity, getNameActivityName)
+		h.RegisterActivityWithAlias(sayGreetingActivity, sayGreetingActivityName)
 		startWorkers(&h)
 
 		// The workers are supposed to be long running process that should not exit.

--- a/cmd/samples/recipes/dynamic/workflow_test.go
+++ b/cmd/samples/recipes/dynamic/workflow_test.go
@@ -1,19 +1,31 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/cadence/testsuite"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/testsuite"
 )
 
 func TestDynamicWorkflow(t *testing.T) {
 	a := assert.New(t)
 	s := testsuite.WorkflowTestSuite{}
 	env := s.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(sampleGreetingsWorkflow)
+	env.RegisterActivityWithOptions(getGreetingActivity, activity.RegisterOptions{
+		Name: getGreetingActivityName,
+	})
+	env.RegisterActivityWithOptions(getNameActivity, activity.RegisterOptions{
+		Name: getNameActivityName,
+	})
+	env.RegisterActivityWithOptions(sayGreetingActivity, activity.RegisterOptions{
+		Name: sayGreetingActivityName,
+	})
 
-	env.OnActivity(getGreetingActivity).Return("Greet", nil).Times(1)
-	env.OnActivity(getNameActivity).Return("Name", nil).Times(1)
-	env.OnActivity(sayGreetingActivity, "Greet", "Name").Return("Greet Name", nil).Times(1)
+	env.OnActivity(getGreetingActivityName).Return("Greet", nil).Times(1)
+	env.OnActivity(getNameActivityName).Return("Name", nil).Times(1)
+	env.OnActivity(sayGreetingActivityName, "Greet", "Name").Return("Greet Name", nil).Times(1)
 
 	env.ExecuteWorkflow(sampleGreetingsWorkflow)
 

--- a/cmd/samples/recipes/helloworld/main.go
+++ b/cmd/samples/recipes/helloworld/main.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/recipes/localactivity/local_activity_workflow.go
+++ b/cmd/samples/recipes/localactivity/local_activity_workflow.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-	"strings"
-	"time"
 )
 
 /**

--- a/cmd/samples/recipes/localactivity/local_activity_workflow_test.go
+++ b/cmd/samples/recipes/localactivity/local_activity_workflow_test.go
@@ -1,60 +1,82 @@
 package main
 
 import (
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/cadence/testsuite"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/testsuite"
 )
 
-func Test_ProcessingWorkflow_SingleAction(t *testing.T) {
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(processingWorkflow)
+	s.env.RegisterWorkflow(signalHandlingWorkflow)
+	s.env.RegisterActivity(activityForCondition0)
+	s.env.RegisterActivity(activityForCondition1)
+	s.env.RegisterActivity(activityForCondition2)
+	s.env.RegisterActivity(activityForCondition3)
+	s.env.RegisterActivity(activityForCondition4)
+}
+
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_ProcessingWorkflow_SingleAction() {
 	signalData := "_1_"
-	testSuite := &testsuite.WorkflowTestSuite{}
-	env := testSuite.NewTestWorkflowEnvironment()
+
 	// mock activityForCondition1 so it won't wait on real clock
-	env.OnActivity(activityForCondition1, mock.Anything, signalData).Return("processed_1", nil)
-	env.ExecuteWorkflow(processingWorkflow, signalData)
-	env.AssertExpectations(t)
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
+	s.env.OnActivity(activityForCondition1, mock.Anything, signalData).Return("processed_1", nil)
+
+	s.env.ExecuteWorkflow(processingWorkflow, signalData)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
 	var actualResult string
-	require.NoError(t, env.GetWorkflowResult(&actualResult))
-	require.Equal(t, "processed_1", actualResult)
+	s.NoError(s.env.GetWorkflowResult(&actualResult))
+	s.Equal("processed_1", actualResult)
 }
 
-func Test_ProcessingWorkflow_MultiAction(t *testing.T) {
+func (s *UnitTestSuite) Test_ProcessingWorkflow_MultiAction() {
 	signalData := "_1_, _3_"
-	testSuite := &testsuite.WorkflowTestSuite{}
-	env := testSuite.NewTestWorkflowEnvironment()
+
 	// mock activityForCondition1 so it won't wait on real clock
-	env.OnActivity(activityForCondition1, mock.Anything, signalData).Return("processed_1", nil)
-	env.OnActivity(activityForCondition3, mock.Anything, signalData).Return("processed_3", nil)
-	env.ExecuteWorkflow(processingWorkflow, signalData)
-	env.AssertExpectations(t)
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
+	s.env.OnActivity(activityForCondition1, mock.Anything, signalData).Return("processed_1", nil)
+	s.env.OnActivity(activityForCondition3, mock.Anything, signalData).Return("processed_3", nil)
+
+	s.env.ExecuteWorkflow(processingWorkflow, signalData)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
 	var actualResult string
-	require.NoError(t, env.GetWorkflowResult(&actualResult))
-	require.Equal(t, "processed_1processed_3", actualResult)
+	s.NoError(s.env.GetWorkflowResult(&actualResult))
+	s.Equal("processed_1processed_3", actualResult)
 }
 
-func Test_SignalHandlingWorkflow(t *testing.T) {
-	testSuite := &testsuite.WorkflowTestSuite{}
-	env := testSuite.NewTestWorkflowEnvironment()
+func (s *UnitTestSuite) Test_SignalHandlingWorkflow() {
+	s.env.OnActivity(activityForCondition1, mock.Anything, "_1_").Return("processed_1", nil)
 
-	env.OnActivity(activityForCondition1, mock.Anything, "_1_").Return("processed_1", nil)
-
-	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("trigger-signal", "_1_")
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow("trigger-signal", "_1_")
 	}, time.Minute)
-
-	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow("trigger-signal", "exit")
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow("trigger-signal", "exit")
 	}, time.Minute*2)
 
-	env.ExecuteWorkflow(signalHandlingWorkflow)
-	env.AssertExpectations(t)
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
+	s.env.ExecuteWorkflow(signalHandlingWorkflow)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }

--- a/cmd/samples/recipes/mutex/mutex_workflow_test.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow_test.go
@@ -16,6 +16,7 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
 	env *testsuite.TestWorkflowEnvironment
 }
 
@@ -25,6 +26,9 @@ func TestUnitTestSuite(t *testing.T) {
 
 func (s *UnitTestSuite) SetupTest() {
 	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(mutexWorkflow)
+	s.env.RegisterWorkflow(sampleWorkflowWithMutex)
+	s.env.RegisterActivity(signalWithStartMutexWorkflowActivity)
 
 	var h common.SampleHelper
 	s.env.SetWorkerOptions(worker.Options{
@@ -32,26 +36,26 @@ func (s *UnitTestSuite) SetupTest() {
 	})
 }
 
-func (s *UnitTestSuite) Test_Workflow_Success() {
-	env := s.NewTestWorkflowEnvironment()
-	mockResourceID := "mockResourceID"
-	MockMutexLock(env, mockResourceID, nil)
-	env.ExecuteWorkflow(sampleWorkflowWithMutex, mockResourceID)
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
-	env.AssertExpectations(s.T())
+func (s *UnitTestSuite) Test_Workflow_Success() {
+	mockResourceID := "mockResourceID"
+	MockMutexLock(s.env, mockResourceID, nil)
+	s.env.ExecuteWorkflow(sampleWorkflowWithMutex, mockResourceID)
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }
 
 func (s *UnitTestSuite) Test_Workflow_Error() {
-	env := s.NewTestWorkflowEnvironment()
 	mockResourceID := "mockResourceID"
-	MockMutexLock(env, mockResourceID, errors.New("bad-error"))
-	env.ExecuteWorkflow(sampleWorkflowWithMutex, mockResourceID)
+	MockMutexLock(s.env, mockResourceID, errors.New("bad-error"))
+	s.env.ExecuteWorkflow(sampleWorkflowWithMutex, mockResourceID)
 
-	s.True(env.IsWorkflowCompleted())
-	s.EqualError(env.GetWorkflowError(), "bad-error")
-	env.AssertExpectations(s.T())
+	s.True(s.env.IsWorkflowCompleted())
+	s.EqualError(s.env.GetWorkflowError(), "bad-error")
 }
 
 func (s *UnitTestSuite) Test_MutexWorkflow_Success() {

--- a/cmd/samples/recipes/mutex/mutex_workflow_test.go
+++ b/cmd/samples/recipes/mutex/mutex_workflow_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 type UnitTestSuite struct {

--- a/cmd/samples/recipes/pickfirst/pickfirst_workflow.go
+++ b/cmd/samples/recipes/pickfirst/pickfirst_workflow.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
-	"time"
 )
 
 /**

--- a/cmd/samples/recipes/query/main.go
+++ b/cmd/samples/recipes/query/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"flag"
+	"time"
+
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
-	"time"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 // This needs to be done as part of a bootstrap step when the process starts.

--- a/cmd/samples/recipes/query/query_workflow.go
+++ b/cmd/samples/recipes/query/query_workflow.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"go.uber.org/cadence/workflow"
 	"time"
+
+	"go.uber.org/cadence/workflow"
 )
 
 // ApplicationName is the task list for this sample

--- a/cmd/samples/recipes/query/query_workflow_test.go
+++ b/cmd/samples/recipes/query/query_workflow_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"github.com/stretchr/testify/require"
-	"go.uber.org/cadence/testsuite"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/cadence/testsuite"
 )
 
 func Test_QueryWorkflow(t *testing.T) {
 	ts := &testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(queryWorkflow)
 
 	w := false
 	env.RegisterDelayedCallback(func() {

--- a/cmd/samples/recipes/retryactivity/retry_activity_workflow.go
+++ b/cmd/samples/recipes/retryactivity/retry_activity_workflow.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"context"
+	"time"
+
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-	"time"
 )
 
 /**

--- a/cmd/samples/recipes/retryactivity/retry_activity_workflow_test.go
+++ b/cmd/samples/recipes/retryactivity/retry_activity_workflow_test.go
@@ -2,28 +2,39 @@ package main
 
 import (
 	"context"
-	"go.uber.org/cadence/activity"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/testsuite"
 )
 
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
 }
 
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(retryWorkflow)
+	s.env.RegisterActivity(batchProcessingActivity)
+}
+
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
+
 func (s *UnitTestSuite) Test_Workflow() {
-	env := s.NewTestWorkflowEnvironment()
 	var startedIDs []int
-	env.OnActivity(batchProcessingActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	s.env.OnActivity(batchProcessingActivity, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, firstTaskID, batchSize int, processDelay time.Duration) error {
 			i := firstTaskID
 			if activity.HasHeartbeatDetails(ctx) {
@@ -36,10 +47,9 @@ func (s *UnitTestSuite) Test_Workflow() {
 
 			return batchProcessingActivity(ctx, firstTaskID, batchSize, time.Nanosecond /* override for test */)
 		})
-	env.ExecuteWorkflow(retryWorkflow)
 
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.env.ExecuteWorkflow(retryWorkflow)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 	s.Equal([]int{0, 6, 12, 18}, startedIDs)
-	env.AssertExpectations(s.T())
 }

--- a/cmd/samples/recipes/searchattributes/main.go
+++ b/cmd/samples/recipes/searchattributes/main.go
@@ -5,11 +5,10 @@ import (
 	"flag"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/pborman/uuid"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
+	"go.uber.org/zap"
 
 	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )

--- a/cmd/samples/recipes/searchattributes/searchattributes_workflow.go
+++ b/cmd/samples/recipes/searchattributes/searchattributes_workflow.go
@@ -5,15 +5,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/cadence/activity"
 	"strconv"
 	"time"
 
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/.gen/go/shared"
+	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 /**

--- a/cmd/samples/recipes/searchattributes/searchattributes_workflow_test.go
+++ b/cmd/samples/recipes/searchattributes/searchattributes_workflow_test.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/testsuite"
-	"testing"
-	"time"
 )
 
 func Test_Workflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(searchAttributesWorkflow)
+	env.RegisterActivity(listExecutions)
 
 	// mock search attributes on start
 	env.SetSearchAttributesOnStart(getSearchAttributesForStart())

--- a/cmd/samples/recipes/sideeffect/sideeffect_workflow.go
+++ b/cmd/samples/recipes/sideeffect/sideeffect_workflow.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"context"
+	"time"
+
 	"github.com/google/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/worker"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-	"time"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
 )
 
 const ApplicationName = "HelloSideEffect"

--- a/cmd/samples/recipes/timer/workflow_test.go
+++ b/cmd/samples/recipes/timer/workflow_test.go
@@ -14,46 +14,50 @@ import (
 type UnitTestSuite struct {
 	suite.Suite
 	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
 }
 
 func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
 }
 
-func (s *UnitTestSuite) Test_Workflow_FastProcessing() {
-	env := s.NewTestWorkflowEnvironment()
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleTimerWorkflow)
+	s.env.RegisterActivity(orderProcessingActivity)
+	s.env.RegisterActivity(sendEmailActivity)
+}
 
+func (s *UnitTestSuite) Test_Workflow_FastProcessing() {
 	// mock to return immediately to simulate fast processing case
-	env.OnActivity(orderProcessingActivity, mock.Anything).Return(nil)
-	env.OnActivity(sendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
+	s.env.OnActivity(orderProcessingActivity, mock.Anything).Return(nil)
+	s.env.OnActivity(sendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
 		// in fast processing case, this method should not get called
 		s.FailNow("sendEmailActivity should not get called")
 		return nil
 	})
 
-	env.ExecuteWorkflow(sampleTimerWorkflow, time.Minute)
-
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.env.ExecuteWorkflow(sampleTimerWorkflow, time.Minute)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
 }
 
 func (s *UnitTestSuite) Test_Workflow_SlowProcessing() {
-	env := s.NewTestWorkflowEnvironment()
-
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	env.OnActivity(orderProcessingActivity, mock.Anything).Return(func(ctx context.Context) error {
+	s.env.OnActivity(orderProcessingActivity, mock.Anything).Return(func(ctx context.Context) error {
 		// simulate slow processing, will complete this activity only after the sendEmailActivity is called.
 		wg.Wait()
 		return nil
 	})
-	env.OnActivity(sendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
+	s.env.OnActivity(sendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
 		wg.Done()
 		return nil
 	})
 
-	env.ExecuteWorkflow(sampleTimerWorkflow, time.Microsecond)
-
-	s.True(env.IsWorkflowCompleted())
-	s.NoError(env.GetWorkflowError())
+	s.env.ExecuteWorkflow(sampleTimerWorkflow, time.Microsecond)
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+	s.env.AssertExpectations(s.T())
 }

--- a/cmd/samples/recovery/recovery_workflow.go
+++ b/cmd/samples/recovery/recovery_workflow.go
@@ -3,16 +3,18 @@ package main
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/pborman/uuid"
-	"github.com/uber-common/cadence-samples/cmd/samples/common"
-	"github.com/uber-common/cadence-samples/cmd/samples/recovery/cache"
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
-	"time"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+	"github.com/uber-common/cadence-samples/cmd/samples/recovery/cache"
 )
 
 type (

--- a/cmd/samples/recovery/trip_workflow.go
+++ b/cmd/samples/recovery/trip_workflow.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
 )

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/uber-go/tally v3.3.11+incompatible
 	go.uber.org/atomic v1.5.1 // indirect
-	go.uber.org/cadence v0.16.1-0.20210416225532-c903538952dc
+	go.uber.org/cadence v0.17.0
 	go.uber.org/net/metrics v1.1.0 // indirect
 	go.uber.org/thriftrw v1.20.2 // indirect
 	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/uber/tchannel-go v1.14.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJV
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=
 go.uber.org/atomic v1.5.1/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/cadence v0.16.1-0.20210416225532-c903538952dc h1:3V9iAvr+ejycoy7HM6mtVisnYhhju7GRqyZ/qYt8YOg=
-go.uber.org/cadence v0.16.1-0.20210416225532-c903538952dc/go.mod h1:R5+LnxVidKynzPYF5bEEW7lYflBuWZZRyt11rvXEETQ=
+go.uber.org/cadence v0.17.0 h1:9cIrCklPRSI5POsr5RKu48/AQVtkiIshbcd7aZ0btIk=
+go.uber.org/cadence v0.17.0/go.mod h1:R5+LnxVidKynzPYF5bEEW7lYflBuWZZRyt11rvXEETQ=
 go.uber.org/dig v1.7.0 h1:E5/L92iQTNJTjfgJF2KgU+/JpMaiuvK2DHLBj0+kSZk=
 go.uber.org/dig v1.7.0/go.mod h1:z+dSd2TP9Usi48jL8M3v63iSBVkiwtVyMKxMZYYauPg=
 go.uber.org/fx v1.9.0 h1:7OAz8ucp35AU8eydejpYG7QrbE8rLKzGhHbZlJi5LYY=


### PR DESCRIPTION
- Fix all unit tests
- Improve package import order
- Use go client version v0.17.0

```
ok      github.com/uber-common/cadence-samples/cmd/samples/cron 0.764s  coverage: 35.3% of statements
?       github.com/uber-common/cadence-samples/cmd/samples/dsl  [no test files]
ok      github.com/uber-common/cadence-samples/cmd/samples/expense      0.678s  coverage: 55.8% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/fileprocessing       10.662s coverage: 62.9% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/branch       0.663s  coverage: 50.0% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/choice       0.631s  coverage: 51.2% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/greetings    0.652s  coverage: 43.9% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/helloworld   0.691s  coverage: 34.3% of statements
?       github.com/uber-common/cadence-samples/cmd/samples/recipes/cancelactivity       [no test files]
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/pickfirst    0.695s  coverage: 48.9% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/mutex        0.733s  coverage: 69.0% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/retryactivity        0.736s  coverage: 58.5% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/splitmerge   0.760s  coverage: 59.0% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/timer        0.825s  coverage: 42.9% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/localactivity        0.885s  coverage: 48.2% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/query        0.781s  coverage: 37.5% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/ctxpropagation       0.821s  coverage: 52.9% of statements
ok      github.com/uber-common/cadence-samples/cmd/samples/recipes/searchattributes     0.941s  coverage: 41.4% of statements
?       github.com/uber-common/cadence-samples/cmd/samples/recovery     [no test files]
ok      github.com/uber-common/cadence-samples/cmd/samples/pso  0.926s  coverage: 61.2% of statements
```