### PR TITLE
Fix samples that cannot run properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ pageflow:
 
 bins: helloworld \
 	branch \
+	cancelactivity \
 	childworkflow \
 	choice \
 	dynamic \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ PROGS = helloworld \
 	ctxpropagation \
 	pso \
 	pageflow \
+	sideeffect \
 
 TEST_ARG ?= -race -v -timeout 5m
 BUILD := ./build
@@ -106,6 +107,9 @@ localactivity:
 query:
 	go build -i -o bin/query cmd/samples/recipes/query/*.go
 
+sideeffect:
+	go build -i -o bin/sideeffect cmd/samples/recipes/sideeffect/*.go
+
 ctxpropagation:
 	go build -i -o bin/ctxpropagation cmd/samples/recipes/ctxpropagation/*.go
 
@@ -133,6 +137,7 @@ pso:
 pageflow:
 	go build -i -o bin/pageflow cmd/samples/pageflow/*.go
 
+
 bins: helloworld \
 	branch \
 	cancelactivity \
@@ -154,6 +159,7 @@ bins: helloworld \
 	localactivity \
 	query \
 	recovery \
+	sideeffect \
 	ctxpropagation \
 	pso \
 	pageflow \

--- a/cmd/samples/recipes/choice/main.go
+++ b/cmd/samples/recipes/choice/main.go
@@ -21,15 +21,7 @@ func startWorkers(h *common.SampleHelper) {
 	}
 
 	// Start Worker.
-	worker := worker.New(
-		h.Service,
-		h.Config.DomainName,
-		ApplicationName,
-		workerOptions)
-	err := worker.Start()
-	if err != nil {
-		panic("Failed to start workers")
-	}
+	h.StartWorkers(h.Config.DomainName, ApplicationName, workerOptions)
 }
 
 func startWorkflowMultiChoice(h *common.SampleHelper) {

--- a/cmd/samples/recipes/mutex/main.go
+++ b/cmd/samples/recipes/mutex/main.go
@@ -24,21 +24,13 @@ const (
 func startWorkers(h *common.SampleHelper) {
 	// Configure worker options.
 	workerOptions := worker.Options{
-		MetricsScope: h.WorkerMetricScope,
-		Logger:       h.Logger,
+		MetricsScope:              h.WorkerMetricScope,
+		Logger:                    h.Logger,
 		BackgroundActivityContext: context.WithValue(context.Background(), _sampleHelperContextKey, h),
 	}
 
 	// Start Worker.
-	worker := worker.New(
-		h.Service,
-		h.Config.DomainName,
-		ApplicationName,
-		workerOptions)
-	err := worker.Start()
-	if err != nil {
-		panic("Failed to start workers")
-	}
+	h.StartWorkers(h.Config.DomainName, ApplicationName, workerOptions)
 }
 
 // startTwoWorkflows starts two workflows that operate on the same recourceID

--- a/cmd/samples/recipes/pickfirst/main.go
+++ b/cmd/samples/recipes/pickfirst/main.go
@@ -21,15 +21,7 @@ func startWorkers(h *common.SampleHelper) {
 	}
 
 	// Start Worker.
-	worker := worker.New(
-		h.Service,
-		h.Config.DomainName,
-		ApplicationName,
-		workerOptions)
-	err := worker.Start()
-	if err != nil {
-		panic("Failed to start workers")
-	}
+	h.StartWorkers(h.Config.DomainName, ApplicationName, workerOptions)
 }
 
 func startWorkflow(h *common.SampleHelper) {

--- a/cmd/samples/recovery/recovery_workflow.go
+++ b/cmd/samples/recovery/recovery_workflow.go
@@ -69,14 +69,6 @@ var (
 	ErrExecutionCacheNotFound = errors.New("failed to retrieve cache from context")
 )
 
-// This is registration process where you register all your workflows
-// and activity function handlers.
-func init() {
-	workflow.RegisterWithOptions(recoverWorkflow, workflow.RegisterOptions{Name: "recoverWorkflow"})
-	activity.Register(listOpenExecutions)
-	activity.Register(recoverExecutions)
-}
-
 // recoverWorkflow is the workflow implementation to recover TripWorkflow executions
 func recoverWorkflow(ctx workflow.Context, params Params) error {
 	logger := workflow.GetLogger(ctx)


### PR DESCRIPTION
## 1. Use `h.StartWorkers`  to start worker

When code uses `worker.New` to create worker, it forgot to register workflows and activities, causing workers not responding to any triggers

Changed samples:
- choice
- mutex
- pickfirst

## 2. Makefile is missing some sample builds

- cancelactivity
- sideeffect

## 3. Remove workflow and activity registering code in `func init()`

it caused `... is already registered` panic.

- samples/recovery
