### PR TITLE
A wrong way of using Selector which cause unhandled signals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ PROGS = helloworld \
 	ctxpropagation \
 	pso \
 	pageflow \
+	signalcounter \
 
 TEST_ARG ?= -race -v -timeout 5m
 BUILD := ./build
@@ -57,6 +58,7 @@ TEST_DIRS=./cmd/samples/cron \
 	./cmd/samples/recipes/query \
 	./cmd/samples/recipes/ctxpropagation \
 	./cmd/samples/recipes/searchattributes \
+	./cmd/samples/recipes/signalcounter \
 	./cmd/samples/recovery \
 	./cmd/samples/pso \
 
@@ -133,6 +135,9 @@ pso:
 pageflow:
 	go build -i -o bin/pageflow cmd/samples/pageflow/*.go
 
+signalcounter:
+	go build -i -o bin/signalcounter cmd/samples/recipes/signalcounter/*.go
+
 bins: helloworld \
 	branch \
 	childworkflow \
@@ -156,6 +161,7 @@ bins: helloworld \
 	ctxpropagation \
 	pso \
 	pageflow \
+	signalcounter \
 
 test: bins
 	@rm -f test

--- a/cmd/samples/recipes/signalcounter/main.go
+++ b/cmd/samples/recipes/signalcounter/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"time"
+
+	"github.com/pborman/uuid"
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+)
+
+// This needs to be done as part of a bootstrap step when the process starts.
+// The workers are supposed to be long running.
+func startWorkers(h *common.SampleHelper) {
+	// Configure worker options.
+	workerOptions := worker.Options{
+		MetricsScope: h.WorkerMetricScope,
+		Logger:       h.Logger,
+	}
+	h.StartWorkers(h.Config.DomainName, ApplicationName, workerOptions)
+}
+
+func startWorkflow(h *common.SampleHelper) {
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                              "signal_counter_" + uuid.New(),
+		TaskList:                        ApplicationName,
+		ExecutionStartToCloseTimeout:    time.Hour,
+		DecisionTaskStartToCloseTimeout: time.Minute,
+	}
+	h.StartWorkflow(workflowOptions, sampleSignalCounterWorkflow, 0)
+}
+
+func main() {
+	var mode string
+	var workflowID string
+	var signalValue int
+	flag.StringVar(&mode, "m", "trigger", "Mode is worker, trigger(start a new workflow), or signal.")
+	flag.StringVar(&workflowID, "w", "", "the workflowID to send signal")
+	flag.IntVar(&signalValue, "sig", 10, "the value that is sent to the counter workflow")
+	flag.Parse()
+
+	var h common.SampleHelper
+	h.SetupServiceConfig()
+
+	switch mode {
+	case "worker":
+		h.RegisterWorkflow(sampleSignalCounterWorkflow)
+		startWorkers(&h)
+
+		// The workers are supposed to be long running process that should not exit.
+		// Use select{} to block indefinitely for samples, you can quit by CMD+C.
+		select {}
+	case "trigger":
+		startWorkflow(&h)
+	case "signal":
+		h.SignalWorkflow(workflowID, "channelA", signalValue)
+	}
+}

--- a/cmd/samples/recipes/signalcounter/signal_counter_workflow.go
+++ b/cmd/samples/recipes/signalcounter/signal_counter_workflow.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"go.uber.org/cadence/workflow"
+)
+
+/**
+ * This sample workflow continuously counting signals and do continue as new
+ */
+
+// ApplicationName is the task list for this sample
+const ApplicationName = "signal_counter"
+// A workflow execution cannot receive infinite number of signals due to history limit
+// By default 10000 is MaximumSignalsPerExecution which can be configured by DynamicConfig of Cadence cluster.
+// But it's recommended to do continueAsNew after receiving 100 signals
+const maxSignalsPerExecution = 10
+
+// sampleSignalCounterWorkflow Workflow Decider.
+func sampleSignalCounterWorkflow(ctx workflow.Context, counter int) error {
+		s := workflow.NewSelector(ctx)
+		signalsPerExecution := 0
+		s.AddReceive(workflow.GetSignalChannel(ctx, "channelA"), func(c workflow.Channel, ok bool) {
+			if ok{
+				var i int
+				c.Receive(ctx, &i)
+				counter += i
+				signalsPerExecution += 1
+			}
+		})
+		s.AddReceive(workflow.GetSignalChannel(ctx, "channelB"), func(c workflow.Channel, ok bool) {
+			if ok{
+				var i int
+				c.Receive(ctx, &i)
+				counter += i
+				signalsPerExecution += 1
+			}
+		})
+
+		var drainedAllSignalsInDecisionTask bool
+		s.AddDefault(func() {
+			// this indicate that we have drained all signals within the decision task, and it's safe to do a continueAsNew
+			drainedAllSignalsInDecisionTask = true
+		})
+
+		for {
+			if signalsPerExecution >= maxSignalsPerExecution && drainedAllSignalsInDecisionTask{
+				return workflow.NewContinueAsNewError(ctx, sampleSignalCounterWorkflow, counter)
+			}
+			s.Select(ctx)
+		}
+}

--- a/cmd/samples/recipes/signalcounter/workflow_test.go
+++ b/cmd/samples/recipes/signalcounter/workflow_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/workflow"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+	s.env.RegisterWorkflow(sampleSignalCounterWorkflow)
+}
+
+func (s *UnitTestSuite) TearDownTest() {
+	s.env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_SampleSignalCounterWorkflow() {
+
+	for i:=0; i< 11; i++{
+		s.env.RegisterDelayedCallback(func() {
+			s.env.SignalWorkflow("channelA", 10)
+		}, 0)
+	}
+
+	s.env.ExecuteWorkflow(sampleSignalCounterWorkflow, 0)
+
+	s.True(s.env.IsWorkflowCompleted())
+	err, ok := s.env.GetWorkflowError().(*workflow.ContinueAsNewError)
+	s.True(ok)
+	s.True(strings.Contains(err.WorkflowType().Name, "sampleSignalCounterWorkflow"))
+	// It should receive and process all 11 signals, even though maxSignalsPerExecution is 10
+	s.Equal(110, err.Args()[0])
+}


### PR DESCRIPTION
You can repro the unhandled signal by these steps:
1. Start the workflow `./bin/signalcounter` , get the `WorkflowID` from the log
2. Run the command 11 times to send 11 signals: `./bin/signalcounter -m signal -w <WorkflowID>`
3. Start the worker `./bin/signalcounter -m worker` and you will see the log like this:
```
(qlong-selector-signal-counter-wrong)$./bin/signalcounter -m worker
2021-07-14T08:53:26.595-0700	INFO	common/sample_helper.go:109	Logger created.
2021-07-14T08:53:26.595-0700	DEBUG	common/factory.go:151	Creating RPC dispatcher outbound{"ServiceName": "cadence-frontend", "HostPort": "127.0.0.1:7933"}
2021-07-14T08:53:26.599-0700	INFO	common/sample_helper.go:161	Domain successfully registered.	{"Domain": "samples-domain"}
2021-07-14T08:53:26.639-0700	INFO	internal/internal_worker.go:833	Started Workflow Worker{"Domain": "samples-domain", "TaskList": "signal_counter", "WorkerID": "96232@IT-USA-25920@signal_counter"}
2021-07-14T08:53:26.639-0700	INFO	internal/internal_worker.go:837	Worker has no activities registered, so activity worker will not be started.	{"Domain": "samples-domain", "TaskList": "signal_counter", "WorkerID": "96232@IT-USA-25920@signal_counter"}
2021-07-14T08:53:26.646-0700	INFO	internal/internal_workflow.go:553	Workflow has unhandled signals	{"Domain": "samples-domain", "TaskList": "signal_counter", "WorkerID": "96232@IT-USA-25920@signal_counter", "WorkflowType": "main.sampleSignalCounterWorkflow", "WorkflowID": "signal_counter_1e89daff-5630-4106-b27d-0b86ee0a3cde", "RunID": "e7ad6861-022f-4595-b9e5-e921c6e6f3de", "SignalNames": ["channelA"]}
```

Unit test would also fail:
```
=== RUN   TestUnitTestSuite/Test_SampleSignalCounterWorkflow
2021-07-14T08:51:59.334-0700	INFO	internal/internal_workflow.go:553	Workflow has unhandled signals	{"SignalNames": ["channelA"]}
    workflow_test.go:47: 
        	Error Trace:	workflow_test.go:47
        	Error:      	Not equal: 
        	            	expected: 110
        	            	actual  : 100
        	Test:       	TestUnitTestSuite/Test_SampleSignalCounterWorkflow
    --- FAIL: TestUnitTestSuite/Test_SampleSignalCounterWorkflow (0.00s)


Expected :110
Actual   :100
```

