### PR TITLE
Add tracing sample with Jaeger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PROGS = helloworld \
 	localactivity \
 	query \
 	cron \
+	tracing \
 	dsl \
 	fileprocessing \
 	dummy \
@@ -109,6 +110,9 @@ query:
 ctxpropagation:
 	go build -i -o bin/ctxpropagation cmd/samples/recipes/ctxpropagation/*.go
 
+tracing:
+	go build -i -o bin/tracing cmd/samples/recipes/tracing/*.go
+
 cron:
 	go build -i -o bin/cron cmd/samples/cron/*.go
 
@@ -147,6 +151,7 @@ bins: helloworld \
 	searchattributes \
 	timer \
 	cron \
+	tracing \
 	dsl \
 	fileprocessing \
 	dummy \

--- a/cmd/samples/common/factory.go
+++ b/cmd/samples/common/factory.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	apiv1 "go.uber.org/cadence/.gen/proto/api/v1"
@@ -30,6 +31,7 @@ type WorkflowClientBuilder struct {
 	Logger         *zap.Logger
 	ctxProps       []workflow.ContextPropagator
 	dataConverter  encoded.DataConverter
+	tracer         opentracing.Tracer
 }
 
 // NewBuilder creates a new WorkflowClientBuilder
@@ -81,6 +83,12 @@ func (b *WorkflowClientBuilder) SetDataConverter(dataConverter encoded.DataConve
 	return b
 }
 
+// SetTracer sets the tracer for the builder
+func (b *WorkflowClientBuilder) SetTracer(tracer opentracing.Tracer) *WorkflowClientBuilder {
+	b.tracer = tracer
+	return b
+}
+
 // BuildCadenceClient builds a client to cadence service
 func (b *WorkflowClientBuilder) BuildCadenceClient() (client.Client, error) {
 	service, err := b.BuildServiceClient()
@@ -96,6 +104,7 @@ func (b *WorkflowClientBuilder) BuildCadenceClient() (client.Client, error) {
 			MetricsScope:       b.metricsScope,
 			DataConverter:      b.dataConverter,
 			ContextPropagators: b.ctxProps,
+			Tracer:             b.tracer,
 			FeatureFlags: client.FeatureFlags{
 				WorkflowExecutionAlreadyCompletedErrorEnabled: true,
 			},

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/cadence/.gen/go/shared"
 
 	prom "github.com/m3db/prometheus_client_golang/prometheus"
@@ -38,6 +39,7 @@ type (
 		CtxPropagators     []workflow.ContextPropagator
 		workflowRegistries []registryOption
 		activityRegistries []registryOption
+		Tracer             opentracing.Tracer
 
 		configFile string
 	}

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -148,6 +148,7 @@ func (h *SampleHelper) SetupServiceConfig() {
 		SetDomain(h.Config.DomainName).
 		SetMetricsScope(h.ServiceMetricScope).
 		SetDataConverter(h.DataConverter).
+		SetTracer(h.Tracer).
 		SetContextPropagators(h.CtxPropagators)
 	service, err := h.Builder.BuildServiceClient()
 	if err != nil {

--- a/cmd/samples/recipes/tracing/helloworld_workflow.go
+++ b/cmd/samples/recipes/tracing/helloworld_workflow.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+/**
+ * This is the tracing hello world workflow sample.
+ */
+
+// ApplicationName is the task list for this sample
+const ApplicationName = "helloWorldGroup"
+
+const helloWorldWorkflowName = "helloWorldWorkflow"
+
+// helloWorkflow workflow decider
+func helloWorldWorkflow(ctx workflow.Context, name string) error {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+		HeartbeatTimeout:       time.Second * 20,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("helloworld workflow started")
+	var helloworldResult string
+	err := workflow.ExecuteActivity(ctx, helloWorldActivity, name).Get(ctx, &helloworldResult)
+	if err != nil {
+		logger.Error("Activity failed.", zap.Error(err))
+		return err
+	}
+
+	logger.Info("Workflow completed.", zap.String("Result", helloworldResult))
+
+	return nil
+}
+
+func helloWorldActivity(ctx context.Context, name string) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("helloworld activity started")
+	return "Hello " + name + "!", nil
+}

--- a/cmd/samples/recipes/tracing/main.go
+++ b/cmd/samples/recipes/tracing/main.go
@@ -51,7 +51,7 @@ func registerWorkflowAndActivity(
 func main() {
 	tracer, closer := initJaeger("cadence-tracing-sample")
 	defer closer.Close()
-
+	
 	var mode string
 	flag.StringVar(&mode, "m", "trigger", "Mode is worker, trigger or shadower.")
 	flag.Parse()
@@ -71,10 +71,6 @@ func main() {
 	case "trigger":
 		startWorkflow(&h)
 	}
-	
-	// span := tracer.StartSpan("say-hello")
-	// println("abcdefb")
-	// span.Finish()
 }
 
 // initJaeger returns an instance of Jaeger Tracer that samples 100% of traces and logs all spans to stdout.

--- a/cmd/samples/recipes/tracing/main.go
+++ b/cmd/samples/recipes/tracing/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/pborman/uuid"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/worker"
+
+	"github.com/uber-common/cadence-samples/cmd/samples/common"
+)
+
+// This needs to be done as part of a bootstrap step when the process starts.
+// The workers are supposed to be long running.
+func startWorkers(h *common.SampleHelper) {
+	// Configure worker options.
+	workerOptions := worker.Options{
+		MetricsScope: h.WorkerMetricScope,
+		Logger:       h.Logger,
+		FeatureFlags: client.FeatureFlags{
+			WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+		},
+		Tracer: h.Tracer,
+	}
+	h.StartWorkers(h.Config.DomainName, ApplicationName, workerOptions)
+}
+
+func startWorkflow(h *common.SampleHelper) {
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                              "helloworld_" + uuid.New(),
+		TaskList:                        ApplicationName,
+		ExecutionStartToCloseTimeout:    time.Minute,
+		DecisionTaskStartToCloseTimeout: time.Minute,
+	}
+	h.StartWorkflow(workflowOptions, helloWorldWorkflowName, "Cadence")
+}
+
+func registerWorkflowAndActivity(
+	h *common.SampleHelper,
+) {
+	h.RegisterWorkflowWithAlias(helloWorldWorkflow, helloWorldWorkflowName)
+	h.RegisterActivity(helloWorldActivity)
+}
+
+func main() {
+	tracer, closer := initJaeger("cadence-tracing-sample")
+	defer closer.Close()
+
+	var mode string
+	flag.StringVar(&mode, "m", "trigger", "Mode is worker, trigger or shadower.")
+	flag.Parse()
+
+	var h common.SampleHelper
+	h.Tracer = tracer
+	h.SetupServiceConfig()
+
+	switch mode {
+	case "worker":
+		registerWorkflowAndActivity(&h)
+		startWorkers(&h)
+
+		// The workers are supposed to be long running process that should not exit.
+		// Use select{} to block indefinitely for samples, you can quit by CMD+C.
+		select {}
+	case "trigger":
+		startWorkflow(&h)
+	}
+	
+	// span := tracer.StartSpan("say-hello")
+	// println("abcdefb")
+	// span.Finish()
+}
+
+// initJaeger returns an instance of Jaeger Tracer that samples 100% of traces and logs all spans to stdout.
+func initJaeger(service string) (opentracing.Tracer, io.Closer) {
+	cfg := &config.Configuration{
+		ServiceName: service,
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+	tracer, closer, err := cfg.NewTracer(config.Logger(jaeger.StdLogger))
+	if err != nil {
+		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
+	}
+	return tracer, closer
+}

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/m3db/prometheus_client_model v0.1.0 // indirect
 	github.com/m3db/prometheus_common v0.1.0 // indirect
 	github.com/m3db/prometheus_procfs v0.8.1 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	github.com/uber-go/tally v3.3.15+incompatible
+	github.com/uber/jaeger-client-go v2.29.1+incompatible // indirect
 	go.uber.org/cadence v0.18.3
 	go.uber.org/yarpc v1.55.0
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 h1:zNBQb37RGLmJybyMcs983HfUfpkw9OTFD9tbBfAViHE=
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
@@ -173,6 +175,8 @@ github.com/uber-go/tally v3.3.15+incompatible h1:9hLSgNBP28CjIaDmAuRTq9qV+UZY+9P
 github.com/uber-go/tally v3.3.15+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.29.1+incompatible h1:R9ec3zO3sGpzs0abd43Y+fBZRJ9uiH6lXyR/+u6brW4=
+github.com/uber/jaeger-client-go v2.29.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/ringpop-go v0.8.5/go.mod h1:zVI6eGO6L7pG14GkntHsSOfmUAWQ7B4lvmzly4IT4ls=


### PR DESCRIPTION
Tested locally
After start jaeger(doc: https://github.com/yurishkuro/opentracing-tutorial ) and local cadence server, and registering the sample domain:

```
(qlong-jaeger) $make tracing
go build -i -o bin/tracing cmd/samples/recipes/tracing/*.go
go build: -i flag is deprecated
qlong@~/indeed/cadence-samples:
(qlong-jaeger) $./bin/tracing -m worker &
[1] 1237
qlong@~/indeed/cadence-samples:
(qlong-jaeger) $2021/10/15 14:21:20 debug logging disabled
2021/10/15 14:21:20 Initializing logging reporter
2021/10/15 14:21:20 debug logging disabled
2021-10-15T14:21:20.760-0700	INFO	common/sample_helper.go:111	Logger created.
2021-10-15T14:21:20.760-0700	DEBUG	common/factory.go:162	Creating RPC dispatcher outbound	{"ServiceName": "cadence-frontend", "HostPort": "127.0.0.1:7833"}
2021-10-15T14:21:20.768-0700	INFO	common/sample_helper.go:164	Domain successfully registered.	{"Domain": "samples-domain"}
2021-10-15T14:21:20.831-0700	INFO	internal/internal_worker.go:833	Started Workflow Worker	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup"}
2021-10-15T14:21:20.840-0700	INFO	internal/internal_worker.go:858	Started Activity Worker	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup"}

qlong@~/indeed/cadence-samples:
(qlong-jaeger) $
qlong@~/indeed/cadence-samples:
(qlong-jaeger) $./bin/tracing
2021/10/15 14:21:24 debug logging disabled
2021/10/15 14:21:24 Initializing logging reporter
2021/10/15 14:21:24 debug logging disabled
2021-10-15T14:21:24.762-0700	INFO	common/sample_helper.go:111	Logger created.
2021-10-15T14:21:24.762-0700	DEBUG	common/factory.go:162	Creating RPC dispatcher outbound	{"ServiceName": "cadence-frontend", "HostPort": "127.0.0.1:7833"}
2021-10-15T14:21:24.770-0700	INFO	common/sample_helper.go:164	Domain successfully registered.	{"Domain": "samples-domain"}
2021/10/15 14:21:24 Reporting span 7b4fdf04426c8d81:7b4fdf04426c8d81:0000000000000000:1
2021-10-15T14:21:24.779-0700	INFO	common/sample_helper.go:198	Started Workflow	{"WorkflowID": "helloworld_7d6c6f4c-d313-4028-acab-db063f51a461", "RunID": "68d4a170-4692-4505-a45b-953e532cf531"}
2021-10-15T14:21:24.797-0700	INFO	tracing/helloworld_workflow.go:31	helloworld workflow started	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup", "WorkflowType": "helloWorldWorkflow", "WorkflowID": "helloworld_7d6c6f4c-d313-4028-acab-db063f51a461", "RunID": "68d4a170-4692-4505-a45b-953e532cf531"}
2021-10-15T14:21:24.797-0700	DEBUG	internal/internal_event_handlers.go:489	ExecuteActivity	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup", "WorkflowType": "helloWorldWorkflow", "WorkflowID": "helloworld_7d6c6f4c-d313-4028-acab-db063f51a461", "RunID": "68d4a170-4692-4505-a45b-953e532cf531", "ActivityID": "0", "ActivityType": "main.helloWorldActivity"}
qlong@~/indeed/cadence-samples:
(qlong-jaeger) $2021-10-15T14:21:24.818-0700	INFO	tracing/helloworld_workflow.go:46	helloworld activity started	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup", "ActivityID": "0", "ActivityType": "main.helloWorldActivity", "WorkflowType": "helloWorldWorkflow", "WorkflowID": "helloworld_7d6c6f4c-d313-4028-acab-db063f51a461", "RunID": "68d4a170-4692-4505-a45b-953e532cf531"}
2021/10/15 14:21:24 Reporting span 7b4fdf04426c8d81:7904de4194461e9e:7b4fdf04426c8d81:1
2021-10-15T14:21:24.839-0700	INFO	tracing/helloworld_workflow.go:39	Workflow completed.	{"Domain": "samples-domain", "TaskList": "helloWorldGroup", "WorkerID": "1237@IT-USA-25920@helloWorldGroup", "WorkflowType": "helloWorldWorkflow", "WorkflowID": "helloworld_7d6c6f4c-d313-4028-acab-db063f51a461", "RunID": "68d4a170-4692-4505-a45b-953e532cf531", "Result": "Hello Cadence!"}
```
![Screen Shot 2021-10-15 at 2 21 44 PM](https://user-images.githubusercontent.com/4523955/137555066-7e01bfd7-901f-474f-bef0-0de744624616.png)

