### PR TITLE
Part 1 of testing the cross-domain feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ default: test
 PROGS = helloworld \
 	branch \
 	childworkflow \
+	crossdomain \
 	choice \
 	dynamic \
 	greetings \
@@ -147,8 +148,17 @@ pageflow:
 signalcounter:
 	go build -i -o bin/signalcounter cmd/samples/recipes/signalcounter/*.go
 
+crossdomain:
+	go build -o bin/crossdomain cmd/samples/recipes/crossdomain/*.go
+
+crossdomain-setup:
+	cadence --ad 127.0.0.1:7933 --env development --do domain0 domain register --ac cluster0 --gd true # global domain required
+	cadence -ad 127.0.0.1:7933 --env development --do domain1 domain register --ac cluster0 --gd true
+	cadence -ad 127.0.0.1:7933 --env development --do domain2 domain register --ac cluster0 --gd true
+
 bins: helloworld \
 	branch \
+	crossdomain \
 	childworkflow \
 	choice \
 	dynamic \

--- a/cmd/samples/recipes/crossdomain/main.go
+++ b/cmd/samples/recipes/crossdomain/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"github.com/google/uuid"
+	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
+	"go.uber.org/cadence/compatibility"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/zap"
+	"time"
+
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/worker"
+)
+
+const (
+	tasklist     = "cross-domain-tl"
+	domain0      = "domain0"
+	domain1      = "domain1"
+	portCluster0 = "127.0.0.1:7833"
+	portCluster1 = "127.0.0.1:8833"
+)
+
+func main() {
+	var mode string
+	flag.StringVar(&mode, "m", "trigger", "Mode is worker, trigger.")
+	flag.Parse()
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+
+	switch mode {
+	case "worker0":
+		setupWorker(domain0, tasklist, portCluster0, []interface{}{wf0}, []interface{}{activity0})
+		setupWorker(domain1, tasklist, portCluster1, []interface{}{wf1}, []interface{}{activity1})
+		logger.Info("workers running for cluster 0....")
+		select {}
+	case "worker1":
+		setupWorker(domain1, tasklist, portCluster1, []interface{}{wf1}, []interface{}{activity1})
+		logger.Info("workers running for cluster 1....")
+		select {}
+	case "cross-cluster":
+		client1 := setupClient(domain0, portCluster0)
+		id := uuid.New().String()
+		res, err := client1.StartWorkflow(context.Background(), client.StartWorkflowOptions{
+			ID:                           id,
+			TaskList:                     tasklist,
+			ExecutionStartToCloseTimeout: 30 * time.Second,
+		}, wf0, "args")
+		if err != nil {
+			logger.Error("error starting workflow", zap.Error(err))
+		}
+		logger.Info("started workflow for domain0", zap.String("wf-id", id), zap.Any("start-wf", res))
+	}
+}
+
+func setupClient(domain string, hostport string) client.Client {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "client",
+		Outbounds: yarpc.Outbounds{
+			"cadence-frontend": {Unary: grpc.NewTransport().NewSingleOutbound(hostport)},
+		},
+	})
+
+	err := dispatcher.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	clientConfig := dispatcher.ClientConfig("cadence-frontend")
+
+	svc := compatibility.NewThrift2ProtoAdapter(
+		apiv1.NewDomainAPIYARPCClient(clientConfig),
+		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+		apiv1.NewWorkerAPIYARPCClient(clientConfig),
+		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+	)
+
+	return client.NewClient(
+		svc,
+		domain,
+		&client.Options{
+			FeatureFlags: client.FeatureFlags{
+				WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+			},
+		})
+}
+func setupWorker(domain string, tl string, hostport string, wfs []interface{}, activities []interface{}) {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "client",
+		Outbounds: yarpc.Outbounds{
+			"cadence-frontend": {Unary: grpc.NewTransport().NewSingleOutbound(hostport)},
+		},
+	})
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err)
+	}
+	err = dispatcher.Start()
+	if err != nil {
+		panic(err)
+	}
+	workerOptions := worker.Options{
+		Logger: logger,
+		FeatureFlags: client.FeatureFlags{
+			WorkflowExecutionAlreadyCompletedErrorEnabled: true,
+		},
+	}
+
+	clientConfig := dispatcher.ClientConfig("cadence-frontend")
+
+	svc := compatibility.NewThrift2ProtoAdapter(
+		apiv1.NewDomainAPIYARPCClient(clientConfig),
+		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+		apiv1.NewWorkerAPIYARPCClient(clientConfig),
+		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+	)
+
+	worker := worker.New(svc, domain, tl, workerOptions)
+	for i := range wfs {
+		worker.RegisterWorkflow(wfs[i])
+	}
+	for i := range activities {
+		worker.RegisterActivity(activities[i])
+	}
+	err = worker.Start()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/samples/recipes/crossdomain/wf.go
+++ b/cmd/samples/recipes/crossdomain/wf.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+	"time"
+)
+
+func wf0(ctx workflow.Context, name string) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("starting child workflow")
+	ctx1 := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		Domain:                       domain1,
+		WorkflowID:                   "wf-domain-1-" + uuid.New().String(),
+		TaskList:                     tasklist,
+		ExecutionStartToCloseTimeout: 1 * time.Minute,
+		//ParentClosePolicy:            client.ParentClosePolicyTerminate,
+	})
+	var res interface{}
+	err := workflow.ExecuteChildWorkflow(ctx1, wf1, "args").Get(ctx1, &res)
+	if err != nil {
+		logger.Error("got error executing child workflow", zap.Error(err))
+	}
+	logger.Info("Workflow wf0 completed.", zap.Any("return-value", res))
+	return nil
+}
+
+func wf1(ctx workflow.Context, name string) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("workflow wf1 completed.")
+	return nil
+}
+
+func activity0(ctx context.Context) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("activity 1 - runnning")
+	return "Hello activity 1!", nil
+}
+func activity1(ctx context.Context) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("activity 2 - runnning")
+	return "Hello - activity 2", nil
+}


### PR DESCRIPTION
Adds a sample worker, workflow and start command for testing the cross-domain feature. In this instance the feature being tested is that of launching a child workflow in a different cluster and different domain.  There are several other scenarios still requiring testing. 

To use this feature, it's necessary to have:
- Global domains
- Replication setup between domains