### PR TITLE
chore: add PR template, guidance, and gitar rule for PR quality

### DIFF
--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -24,7 +24,7 @@ From https://cbea.ms/git-commit/#why-not-how:
 
 ### Required Sections (must exist with substantive content per PR template guidance)
 
-1. **Which sample(s) or area?** (optional but recommended)
+1. **Which sample(s) or area?** 
    - One line listing area(s) touched. This repo has two sample trees: **cmd/samples** (legacy; make + ./bin/…) and **new_samples** (per-folder; go run .). Identify which tree and area(s) are touched.
    - **cmd/samples:** e.g. cmd/samples/recipes/helloworld, cmd/samples/recipes/branch, cmd/samples/recipes/query, cmd/samples/batch, cmd/samples/cron, cmd/samples/expense, cmd/samples/fileprocessing, cmd/samples/dsl, cmd/samples/pso, cmd/samples/recovery, cmd/samples/recipes/cancelactivity, etc.
    - **new_samples:** hello_world, activities, query, signal, operations, client_tls, template.

--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -1,0 +1,85 @@
+---
+title: PR Description Quality Standards
+description: Ensures PR descriptions meet quality criteria for the cadence-samples (Go) repo using guidance from the PR template and .github/pull_request_guidance.md
+when: PR description is created or updated
+actions: Read PR template and guidance, then report requirement status
+---
+
+# PR Description Quality Standards
+
+When evaluating a pull request description:
+
+1. **Read the PR template guidance** at `.github/pull_request_guidance.md` to understand the expected guidance for each section
+2. Apply that guidance to evaluate the current PR description
+3. Provide recommendations for how to improve the description.
+
+## Core Principle: Why Not How
+
+From https://cbea.ms/git-commit/#why-not-how:
+- **"A diff shows WHAT changed, but only the description can explain WHY"**
+- Focus on: the problem being solved, the reasoning behind the solution, context
+- The code itself documents HOW - the PR description documents WHY
+
+## Evaluation Criteria
+
+### Required Sections (must exist with substantive content per PR template guidance)
+
+1. **Which sample(s) or area?** (optional but recommended)
+   - One line listing area(s) touched. This repo has two sample trees: **cmd/samples** (legacy; make + ./bin/…) and **new_samples** (per-folder; go run .). Identify which tree and area(s) are touched.
+   - **cmd/samples:** e.g. cmd/samples/recipes/helloworld, cmd/samples/recipes/branch, cmd/samples/recipes/query, cmd/samples/batch, cmd/samples/cron, cmd/samples/expense, cmd/samples/fileprocessing, cmd/samples/dsl, cmd/samples/pso, cmd/samples/recovery, cmd/samples/recipes/cancelactivity, etc.
+   - **new_samples:** hello_world, activities, query, signal, operations, client_tls, template.
+   - **Other:** README, build, config, Makefile, common.
+   - Helps reviewers route; skip flagging if area is obvious from paths
+
+2. **What changed?**
+   - 1-2 line summary of WHAT changed technically
+   - Focus on key modification, not implementation details
+   - Link to GitHub issue encouraged for non-trivial changes; optional for trivial doc/sample tweaks
+   - Template has good/bad examples
+
+3. **Why?**
+   - Context and motivation (why not how)
+   - Enough rationale for reviewers to understand the goal (e.g. improving clarity, fixing compatibility, aligning with docs)
+   - Must explain WHY this approach was chosen
+
+4. **How did you test it?**
+   - Concrete, copyable commands with exact invocations
+   - GOOD: `make`, `go test ./...`, `go test ./cmd/samples/recipes/helloworld/`, `cd new_samples/hello_world && go run .`, and Cadence CLI commands as in sample READMEs
+   - BAD: "Tested locally" or "See tests"
+   - Expect Go/make and/or sample execution commands; no canary or integration server setup required
+
+5. **Potential risks**
+   - Often N/A for sample-only or doc-only changes
+   - Call out when relevant: dependency upgrades, behavior changes for someone copying the sample, build/config changes
+   - Don't require lengthy text when N/A is appropriate
+
+6. **Release notes**
+   - Optional for this repo. Use when change is user-facing (e.g. new sample, notable README change)
+   - Can be N/A for internal refactors or tiny fixes
+   - Don't require lengthy text when N/A is appropriate
+
+7. **Documentation Changes**
+   - Often relevant when adding or changing samples (main README, cmd/samples READMEs, new_samples READMEs including generator-generated, links to cadence or cadence-docs)
+   - Only mark N/A if certain no docs are affected
+
+### Quality Checks
+
+- **Skip obvious things** - Don't flag items clear from folder structure (e.g. area from paths)
+- **Skip trivial refactors** - Minor formatting/style changes don't need deep rationale
+- **Don't check automated items** - CI, linting are automated
+
+## FORBIDDEN - Never Include
+
+- "Issues Found", "Testing Evidence Quality", "Documentation Reasoning", "Summary" sections
+- "Note:" paragraphs or explanatory text outside recommendations
+- Grouping recommendations by type
+
+## Section Names (Use EXACT Brackets)
+
+- **[Which sample(s) or area?]**
+- **[What changed?]**
+- **[Why?]**
+- **[How did you test it?]**
+- **[Potential risks]**
+- **[Release notes]**
+- **[Documentation Changes]**

--- a/.github/pull_request_guidance.md
+++ b/.github/pull_request_guidance.md
@@ -1,0 +1,48 @@
+<!-- List the area(s) touched so reviewers know where to look.
+This repo has two sample trees: legacy samples under cmd/samples (built with make, run via ./bin/<name>) and newer samples under new_samples (per-folder, run with go run .). Naming the area helps reviewers.
+Examples: cmd/samples/recipes/helloworld, cmd/samples/batch, cmd/samples/expense, new_samples/hello_world, new_samples/query, new_samples/operations, README, build, config, Makefile -->
+**Which sample(s) or area?**
+
+
+<!-- 1-2 line summary of WHAT changed technically.
+- Link to a GitHub issue when applicable (encouraged for larger changes; optional for trivial doc/sample tweaks)
+- Good: "Added CancelWorkflow sample in new_samples/operations" or "Updated README run instructions for Go 1.21"
+- Bad: "updated code" or "fixed stuff" -->
+**What changed?**
+
+
+<!-- Provide context and motivation (see https://cbea.ms/git-commit/#why-not-how). Focus on WHY, not how.
+- Lighter than core Cadence repo: e.g. "improving clarity for new users," "fixing sample broken on Go 1.21," "aligning with cadence-docs"
+- Still give enough rationale for reviewers to understand the goal
+- Good: "HelloWorld didn't show retry behavior; this sample demonstrates RetryOptions so users can copy-paste a working example."
+- Bad: "Improves samples" -->
+**Why?**
+
+
+<!-- Include concrete, copy-paste commands so another maintainer can reproduce your test steps.
+- Prefer: make, go test ./... (or a targeted test, e.g. go test ./cmd/samples/recipes/helloworld/)
+- For cmd/samples: make then e.g. ./bin/helloworld -m worker and ./bin/helloworld -m trigger
+- For new_samples: cd new_samples/<sample> && go run . and Cadence CLI commands as in the sample README
+- Good: Full commands reviewers can copy-paste to verify
+- Bad: "Tested locally" or "See tests" -->
+**How did you test it?**
+
+
+<!-- Often N/A for sample-only or doc-only changes. Call out when relevant:
+- Dependency upgrades (e.g. cadence-client version)
+- Behavior changes that could affect someone copying the sample
+- Build or config changes
+- If truly N/A, you can mark it as such -->
+**Potential risks**
+
+
+<!-- Optional for this repo. Use when the change is user-facing (e.g. new sample, notable README change).
+- Can be N/A for internal refactors, tiny fixes, or incremental work -->
+**Release notes**
+
+
+<!-- Did you update the main README, a cmd/samples README, or a new_samples README (including generator-generated READMEs)?
+- Any links to cadence or cadence-docs that need updating?
+- Only mark N/A if you're certain no docs are affected -->
+**Documentation Changes**
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-<!-- If you are new to contributing or want a refresher, please read .github/pull_request_guidance.md -->
+<!-- For guidance on each section, see the PR guidance doc:
+     https://github.com/cadence-workflow/cadence-samples/blob/master/.github/pull_request_guidance.md -->
 **Which sample(s) or area?**
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- If you are new to contributing or want a refresher, please read .github/pull_request_guidance.md -->
+**Which sample(s) or area?**
+
+
+**What changed?**
+
+
+**Why?**
+
+
+**How did you test it?**
+
+
+**Potential risks**
+
+
+**Release notes**
+
+
+**Documentation Changes**
+


### PR DESCRIPTION

### Summary

Adds PR quality automation:  a pull request template, a guidance document that explains each section, and a gitar rule for automated PR description checks. All three are tailored to cadence-samples (Go, two sample trees).

### Changes

- **`.github/pull_request_template.md`** — Minimal template with sections: Which sample(s) or area?, What changed?, Why?, How did you test it?, Potential risks, Release notes, Documentation Changes. Links to the guidance doc.
- **`.github/pull_request_guidance.md`** — Section-by-section guidance with cadence-samples-specific examples: both sample trees (`cmd/samples` vs `new_samples`), Go/make test commands (`make`, `go test ./...`, `cd new_samples/<sample> && go run .`, Cadence CLI), and good/bad examples.
- **`.gitar/rules/pr-description-quality.md`** — Gitar rule that runs when a PR description is created or updated. Evaluates descriptions against the template and guidance; understands both sample trees and expects concrete Go/make test commands. 
- 
### Why?

- Gives contributors a clear, consistent structure for PR descriptions.
- Keeps the template short by moving detailed instructions into the guidance doc.
- Enables automated checks (gitar) so PR descriptions meet the same bar without cluttering the template.

### How did you test it?

- Reviewed the three files for correctness and that examples match this repo (cmd/samples vs new_samples, Go/make).
- Confirmed section names align across template, guidance, and gitar rule.

### Potential risks

N/A — docs and automation config only; no runtime or build behavior change.

### Release notes

N/A — internal process/contributor experience only.

### Documentation Changes

- New `.github/pull_request_template.md` and `.github/pull_request_guidance.md` (contributor-facing).
- New `.gitar/rules/pr-description-quality.md` (automation config). No updates to main README or sample READMEs.