### PR TITLE
refactor(query): drop blocks package, use Cadence Web markdown format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ test.log
 vendor/
 # Executables produced by cadence-samples repo
 bin/
+# Binary from go build in new_samples/query
+new_samples/query/query
 docker-compose.yml
 
 # Credentials

--- a/new_samples/query/lunch_vote_workflow.go
+++ b/new_samples/query/lunch_vote_workflow.go
@@ -6,9 +6,15 @@ import (
 	"time"
 
 	"go.uber.org/cadence/workflow"
-	"go.uber.org/cadence/x/blocks"
 	"go.uber.org/zap"
 )
+
+// lunchVoteFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type lunchVoteFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
 
 // LunchVoteWorkflow demonstrates using MarkDoc query responses for interactive voting.
 // Users can vote for lunch options via signal buttons rendered in the query response.
@@ -18,7 +24,7 @@ func LunchVoteWorkflow(ctx workflow.Context) error {
 
 	votes := []map[string]string{}
 
-	workflow.SetQueryHandler(ctx, "options", func() (blocks.QueryResponse, error) {
+	workflow.SetQueryHandler(ctx, "options", func() (lunchVoteFormattedResponse, error) {
 		logger := workflow.GetLogger(ctx)
 		logger.Info("Responding to 'options' query")
 
@@ -47,7 +53,7 @@ func LunchVoteWorkflow(ctx workflow.Context) error {
 }
 
 // makeLunchVoteResponse creates the MarkDoc query response for lunch voting
-func makeLunchVoteResponse(ctx workflow.Context, votes []map[string]string) blocks.QueryResponse {
+func makeLunchVoteResponse(ctx workflow.Context, votes []map[string]string) lunchVoteFormattedResponse {
 	type P map[string]interface{}
 
 	markdownTemplate, err := template.New("").Parse(`
@@ -116,7 +122,11 @@ We're voting on where to order lunch today. Select the option you want to vote f
 		panic("Failed to execute template: " + err.Error())
 	}
 
-	return blocks.New(blocks.NewMarkdownSection(markdown.String()))
+	return lunchVoteFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
 }
 
 // makeLunchVoteTable generates a markdown table of current votes

--- a/new_samples/query/markdown_query.go
+++ b/new_samples/query/markdown_query.go
@@ -9,13 +9,19 @@ import (
 
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
-	"go.uber.org/cadence/x/blocks"
 	"go.uber.org/zap"
 )
 
 const (
 	CompleteSignalChan = "complete"
 )
+
+// markdownFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type markdownFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
 
 func MarkdownQueryWorkflow(ctx workflow.Context) error {
 	ao := workflow.ActivityOptions{
@@ -26,7 +32,7 @@ func MarkdownQueryWorkflow(ctx workflow.Context) error {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("MarkdownQueryWorkflow started")
 
-	workflow.SetQueryHandler(ctx, "Signal", func() (blocks.QueryResponse, error) {
+	workflow.SetQueryHandler(ctx, "Signal", func() (markdownFormattedResponse, error) {
 		logger := workflow.GetLogger(ctx)
 		logger.Info("Responding to 'Signal' query")
 
@@ -57,7 +63,7 @@ func MarkdownQueryWorkflow(ctx workflow.Context) error {
 	}
 }
 
-func makeMarkdownQueryResponse(ctx workflow.Context) blocks.QueryResponse {
+func makeMarkdownQueryResponse(ctx workflow.Context) markdownFormattedResponse {
 	type P map[string]interface{}
 
 	markdownTemplate, err := template.New("").Parse(`
@@ -114,7 +120,11 @@ func makeMarkdownQueryResponse(ctx workflow.Context) blocks.QueryResponse {
 		panic("Failed to execute template: " + err.Error())
 	}
 
-	return blocks.New(blocks.NewMarkdownSection(markdown.String()))
+	return markdownFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
 }
 
 func MarkdownQueryActivity(ctx context.Context, complete bool) (string, error) {

--- a/new_samples/query/order_fulfillment_workflow.go
+++ b/new_samples/query/order_fulfillment_workflow.go
@@ -7,9 +7,15 @@ import (
 	"time"
 
 	"go.uber.org/cadence/workflow"
-	"go.uber.org/cadence/x/blocks"
 	"go.uber.org/zap"
 )
+
+// orderDashboardFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type orderDashboardFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
 
 // Order represents an e-commerce order being fulfilled
 type Order struct {
@@ -114,7 +120,7 @@ func OrderFulfillmentWorkflow(ctx workflow.Context) error {
 	}
 
 	// Register query handler for the ops dashboard
-	workflow.SetQueryHandler(ctx, "dashboard", func() (blocks.QueryResponse, error) {
+	workflow.SetQueryHandler(ctx, "dashboard", func() (orderDashboardFormattedResponse, error) {
 		logger.Info("Responding to 'dashboard' query")
 		return makeOrderDashboard(ctx, order, actionLog), nil
 	})
@@ -259,7 +265,7 @@ func getOperator(operator string) string {
 	return operator
 }
 
-func makeOrderDashboard(ctx workflow.Context, order Order, actionLog []ActionLogEntry) blocks.QueryResponse {
+func makeOrderDashboard(ctx workflow.Context, order Order, actionLog []ActionLogEntry) orderDashboardFormattedResponse {
 	type P map[string]interface{}
 
 	markdownTemplate, err := template.New("").Parse(`
@@ -330,7 +336,11 @@ func makeOrderDashboard(ctx workflow.Context, order Order, actionLog []ActionLog
 		panic("Failed to execute template: " + err.Error())
 	}
 
-	return blocks.New(blocks.NewMarkdownSection(markdown.String()))
+	return orderDashboardFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
 }
 
 func getStatusBadge(status string) string {


### PR DESCRIPTION

### Summary

Removes the deprecated `go.uber.org/cadence/x/blocks` dependency from the three query samples (markdown_query, order_fulfillment, lunch_vote) and switches to the simple formatted-data JSON that Cadence Web supports for markdown query results. Each workflow is self-contained with its own response struct.

### Changes

- **markdown_query.go, order_fulfillment_workflow.go, lunch_vote_workflow.go**: Dropped `go.uber.org/cadence/x/blocks` import. Query handlers now return a struct that serializes to `{ "cadenceResponseType": "formattedData", "format": "text/markdown", "data": "<markdown>" }` so Cadence Web still renders markdown.
- **.gitignore**: Added `new_samples/query/query` so the binary produced by `go build .` in that directory is not tracked.

### Why?

The blocks package is being deprecated. Cadence Web accepts a simpler JSON shape for markdown; using it keeps the samples working without the deprecated dependency and keeps each sample in a single file.

### How did you test it?

1. **Start the worker** (from repo root or `new_samples/query`):
   ```bash
   cd new_samples/query && go run .
   ```

2. **Markdown Query Workflow** start workflow, then in Cadence Web open the workflow → Query tab → select "Signal" and confirm markdown (and buttons) render:

  cadence --domain cadence-samples \
    workflow start \
    --tl cadence-samples-worker \
    --et 1000 \
    --workflow_type cadence_samples.MarkdownQueryWorkflow


 4.  **Lunch Vote Workflow**  start workflow, then in Cadence Web → Query tab → "options"; confirm markdown and vote buttons:

 cadence --domain cadence-samples \
  workflow start \
  --tl cadence-samples-worker \
  --et 600 \
  --workflow_type cadence_samples.LunchVoteWorkflow


5. **Order Fulfillment Workflow** start workflow, then in Cadence Web → Query tab → "dashboard"; confirm order dashboard markdown and action buttons:

cadence --domain cadence-samples \
  workflow start \
  --tl cadence-samples-worker \
  --et 3600 \
  --workflow_type cadence_samples.OrderFulfillmentWorkflow



### Potential risks

N/A — same JSON contract from Cadence Web’s perspective; only the Go type and removal of the blocks import change.

### Release notes

N/A — sample-only change.

### Documentation Changes

N/A — no README or doc updates.