### PR TITLE
docs: refactor agent_handoffs README for proper markdown rendering

### DIFF
--- a/python_sdk_samples/openai_samples/agent_handoffs/README.md
+++ b/python_sdk_samples/openai_samples/agent_handoffs/README.md
@@ -1,10 +1,10 @@
 # What
 
-This demo shows how to run OpenAI agents in a durable way (retries, reset to a check point). Specifically, we show the execution of a mutli-agent system with handoffs.
+This demo shows how to run OpenAI agents in a durable way (retries, reset to a check point). Specifically, we show the execution of a multi-agent system with handoffs.
 
 # Setup OpenAI API keys
 
-Make sure OPENAI_API_KEY environment variable is set. See details for best practices.
+Make sure the OPENAI_API_KEY environment variable is set. See details for best practices.
 https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety
 
 # Setup Cadence Server
@@ -28,10 +28,10 @@ uv run python -m openai_samples.agent_handoffs.main
 Run Cadence CLI command
 
 ```
-cadence --domain default workflow start
---workflow_type BookTripAgentWorkflow
---tasklist agent-task-list
---execution_timeout 30
+cadence --domain default workflow start \
+--workflow_type BookTripAgentWorkflow \
+--tasklist agent-task-list \
+--execution_timeout 30 \
 --input '"Book a trip for me from Uber Seattle Office to Uber San Francisco Office tomorrow at 10:00 AM"'
 ```
 


### PR DESCRIPTION
<!-- For guidance on each section, see the PR guidance doc:
     https://github.com/cadence-workflow/cadence-samples/blob/master/.github/pull_request_guidance.md -->
**Which sample(s) or area?**
agent_handoffs

**What changed?**
 - Renamed to README.md for proper markdown rendering
-  adjusted the example of Cadence CLI command

**Why?**
The file already contains markdown content (images, CLI command examples) and without .md extension, some tools and repos treat it as plain text, which makes it harder to read.

**How did you test it?**


**Potential risks**


**Release notes**


**Documentation Changes**

