### PR TITLE
feat(data): add encryption and S3 DataConverter samples

### DIFF
--- a/new_samples/README.md
+++ b/new_samples/README.md
@@ -8,6 +8,7 @@ This directory contains samples demonstrating various Cadence workflow concepts.
 |--------|-------------|
 | [activities/](activities/) | Activity patterns: dynamic execution by name, parallel execution with pick-first |
 | [client_tls/](client_tls/) | Client-side TLS configuration for secure Cadence connections |
+| [data/](data/) | Custom DataConverters: gzip compression, AES-256-GCM encryption, and S3 "claim-check" offload |
 | [hello_world/](hello_world/) | Basic "Hello World" workflow and activity |
 | [operations/](operations/) | Workflow operations: cancellation and cleanup patterns |
 | [query/](query/) | Workflow query patterns |

--- a/new_samples/data/README.md
+++ b/new_samples/data/README.md
@@ -29,69 +29,133 @@ go run .
 
 This will call the main function in main.go which starts the worker, which will be execute the sample workflow code
 
-## Samples in this folder
+## Data Converter Samples
 
-This folder contains samples demonstrating custom data conversion patterns in Cadence.
+This folder demonstrates three production-ready patterns for custom `DataConverter` implementations in Cadence. A `DataConverter` controls how every workflow input, output, and activity parameter is serialized before it is written to Cadence history — making it the right place to add compression, encryption, or external offloading without changing any workflow or activity code.
 
-### Data Converter Workflow
+### What is a DataConverter?
 
-The `LargeDataConverterWorkflow` demonstrates how to use custom data converters with compression capabilities. Data converters control how workflow inputs, outputs, and activity parameters are serialized and deserialized.
+A `DataConverter` implements two methods:
 
-#### What is a DataConverter?
+- `ToData(value ...interface{}) ([]byte, error)` — called before data is written to Cadence history
+- `FromData(input []byte, valuePtr ...interface{}) error` — called when data is read back
 
-A `DataConverter` is responsible for:
-- Serializing workflow inputs and activity parameters before storage
-- Deserializing workflow outputs and activity results when retrieved
-- Enabling custom encoding formats (compression, encryption, etc.)
+The same `DataConverter` must be used by **both the worker and any client that triggers or queries the workflow**. In this sample the workflows generate their own payloads internally, so they can be started from the Cadence CLI without bundling a custom converter into the CLI itself.
 
-#### The Compressed JSON DataConverter
+Each sample runs its own worker on its own task list so it can use its own `DataConverter`. Start all three with a single `go run .`.
 
-This sample implements `compressedJSONDataConverter` which:
-- Serializes data to JSON format
-- Compresses using gzip to reduce storage size
-- Automatically decompresses when reading data back
+---
 
-#### Compression Benefits
+### Compression Sample
 
-For large payloads, compression typically provides:
-- **60-80% size reduction** for JSON data
-- **Lower storage costs** in Cadence history
-- **Reduced bandwidth** for data transfer
-- **Better scalability** with large payloads
+`CompressionDataConverterWorkflow` demonstrates gzip-over-JSON compression. For repetitive JSON data this typically achieves 60–80% size reduction, lowering storage costs and bandwidth for large workflow payloads.
 
-#### Use Cases
-
-Custom DataConverters are useful when you need to:
-- Reduce storage costs with compression
-- Add encryption/decryption for sensitive data
-- Support legacy serialization formats
-- Implement custom compression algorithms (LZ4, Snappy, etc.)
-- Add data validation during serialization
-
-#### How to Start the Workflow
+**Task list:** `cadence-samples-data-compression`
 
 ```bash
 cadence --domain cadence-samples \
   workflow start \
-  --workflow_type cadence_samples.LargeDataConverterWorkflow \
-  --tl cadence-samples-worker \
+  --workflow_type cadence_samples.CompressionDataConverterWorkflow \
+  --tl cadence-samples-data-compression \
   --et 60
 ```
 
-Note: The workflow generates its own large payload internally - no input is required. This design allows the workflow to be started from CLI without the client needing the custom DataConverter. The compression demonstration happens when data is passed between the workflow and activity. When the worker starts, it displays compression statistics showing the before/after sizes.
+When the worker starts it prints a compression statistics banner showing the before/after sizes of the sample payload so you can see the benefit immediately.
 
-#### Key Implementation Details
+---
 
-The custom DataConverter is configured in `worker.go`:
+### Encryption Sample
 
-```go
-workerOptions := worker.Options{
-    DataConverter: NewCompressedJSONDataConverter(),
-    // ... other options
-}
+`EncryptionDataConverterWorkflow` demonstrates AES-256-GCM encryption. Every workflow input, output, and activity parameter is encrypted before being written to Cadence history. Without the key, the data stored by the Cadence server — including any operators browsing workflow history — is completely opaque.
+
+The sample uses a `SensitiveCustomerRecord` containing realistic PII and PHI fields (name, email, SSN, credit card, medical notes) to make the use case concrete.
+
+**Task list:** `cadence-samples-data-encryption`
+
+```bash
+cadence --domain cadence-samples \
+  workflow start \
+  --workflow_type cadence_samples.EncryptionDataConverterWorkflow \
+  --tl cadence-samples-data-encryption \
+  --et 60
 ```
 
-Both the worker AND any client triggering workflows must use the same DataConverter to properly encode/decode data.
+#### Encryption key
+
+By default, the worker uses a hardcoded demo key and prints a prominent warning. To use your own key:
+
+```bash
+# Generate a random 32-byte (256-bit) key
+export CADENCE_ENCRYPTION_KEY=$(openssl rand -hex 32)
+go run .
+```
+
+> **WARNING:** The hardcoded demo key (`cadence-demo-key-NOT-FOR-PROD!!!`) is public.
+> Never use it in production. In production, load your key from a secrets manager
+> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.) and rotate it regularly.
+
+#### How AES-256-GCM works
+
+- `ToData`: JSON-encode arguments → generate a 12-byte random nonce → `cipher.AEAD.Seal` → return `nonce || ciphertext+tag`.
+- `FromData`: split nonce from input → `cipher.AEAD.Open` → JSON-decode.
+
+The GCM authentication tag (16 bytes) ensures ciphertext tampering is detected. The random nonce means the same plaintext produces different ciphertext on every call, preventing replay detection by an attacker who observes Cadence history.
+
+---
+
+### S3 Offload Sample (Claim-Check Pattern)
+
+`S3OffloadDataConverterWorkflow` demonstrates the *claim-check* pattern: payloads larger than a configurable threshold are stored in an external `BlobStore` and only a small reference (a few dozen bytes) travels through Cadence workflow history.
+
+This solves the practical problem of Cadence's per-payload size limits (~2 MB) for workflows that must pass very large datasets between the workflow and its activities.
+
+**Task list:** `cadence-samples-data-s3`
+
+```bash
+cadence --domain cadence-samples \
+  workflow start \
+  --workflow_type cadence_samples.S3OffloadDataConverterWorkflow \
+  --tl cadence-samples-data-s3 \
+  --et 60
+```
+
+#### How it works
+
+- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a UUID key and return `0x01 || {"__s3_ref":"<bucket>/<uuid>"}`. Otherwise return `0x00 || json` inline.
+- `FromData`: read prefix byte → if `0x01`, fetch from `BlobStore` and decode; if `0x00`, decode inline.
+
+#### Default store (zero-config)
+
+Out of the box, `localFSBlobStore` writes blobs to `os.TempDir()/cadence-samples-data-s3/`. No cloud credentials or additional dependencies are needed.
+
+#### Swapping in real AWS S3
+
+The file `s3_dataconverter_workflow.go` contains a commented `s3BlobStore` stub showing the exact AWS SDK calls needed. To enable it:
+
+1. Add the AWS SDK to your module:
+   ```bash
+   go get github.com/aws/aws-sdk-go-v2/config
+   go get github.com/aws/aws-sdk-go-v2/service/s3
+   ```
+2. Uncomment the `s3BlobStore` section in `s3_dataconverter_workflow.go`.
+3. Replace `NewLocalFSBlobStore()` with `NewS3BlobStore(bucket, region)` in `worker.go`.
+4. Set standard AWS environment variables (`AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or use an IAM instance role.
+
+You can also point the SDK at [LocalStack](https://localstack.cloud/) or [MinIO](https://min.io/) for local testing without a real AWS account.
+
+> **Note on cleanup:** The `s3OffloadDataConverter` does not delete blobs after the workflow completes. In production, use S3 object lifecycle policies to automatically expire old blobs.
+
+---
+
+### When to use which pattern
+
+| Pattern | Best for |
+|---------|----------|
+| **Compression** | Large repetitive JSON payloads; reducing storage cost without confidentiality requirements |
+| **Encryption** | PII, PHI, secrets, or any data that must be unreadable in Cadence history |
+| **S3 Offload** | Payloads approaching Cadence's size limits; binary or non-JSON data; cost-conscious archival |
+
+Patterns can be composed: encrypt-then-compress, or encrypt-then-offload to S3 for maximum security and minimum history size.
 
 ## References
 

--- a/new_samples/data/README.md
+++ b/new_samples/data/README.md
@@ -121,7 +121,7 @@ cadence --domain cadence-samples \
 
 #### How it works
 
-- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a UUID key and return `0x01 || {"__s3_ref":"<bucket>/<uuid>"}`. Otherwise return `0x00 || json` inline.
+- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a SHA-256 key and return `0x01 || {"__s3_ref":"<bucket>/<sha256hex>"}`. Otherwise return `0x00 || json` inline.
 - `FromData`: read prefix byte → if `0x01`, fetch from `BlobStore` and decode; if `0x00`, decode inline.
 
 #### Default store (zero-config)

--- a/new_samples/data/README.md
+++ b/new_samples/data/README.md
@@ -92,7 +92,7 @@ go run .
 
 > **WARNING:** The hardcoded demo key (`cadence-demo-key-NOT-FOR-PROD!!!`) is public.
 > Never use it in production. In production, load your key from a secrets manager
-> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.) and rotate it regularly.
+> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.).
 
 #### How AES-256-GCM works
 

--- a/new_samples/data/compressed_dataconverter_workflow.go
+++ b/new_samples/data/compressed_dataconverter_workflow.go
@@ -281,12 +281,12 @@ func GetPayloadSizeInfo(payload LargePayload, converter encoded.DataConverter) (
 	return originalSize, compressedSize, compressionPercentage, nil
 }
 
-// LargeDataConverterWorkflow demonstrates processing large payloads with compression.
+// CompressionDataConverterWorkflow demonstrates processing large payloads with compression.
 // The DataConverter automatically compresses/decompresses all workflow data.
 // Note: The workflow generates its own payload internally so it can be started from CLI
 // without requiring the CLI to use the custom DataConverter. The compression demonstration
 // happens when data is passed between workflow and activity.
-func LargeDataConverterWorkflow(ctx workflow.Context) (LargePayload, error) {
+func CompressionDataConverterWorkflow(ctx workflow.Context) (LargePayload, error) {
 	logger := workflow.GetLogger(ctx)
 
 	// Generate the large payload internally - this allows the workflow to be started
@@ -304,7 +304,7 @@ func LargeDataConverterWorkflow(ctx workflow.Context) (LargePayload, error) {
 	ctx = workflow.WithActivityOptions(ctx, activityOptions)
 
 	var result LargePayload
-	err := workflow.ExecuteActivity(ctx, LargeDataConverterActivity, input).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, CompressionDataConverterActivity, input).Get(ctx, &result)
 	if err != nil {
 		logger.Error("Large payload activity failed", zap.Error(err))
 		return LargePayload{}, err
@@ -315,9 +315,9 @@ func LargeDataConverterWorkflow(ctx workflow.Context) (LargePayload, error) {
 	return result, nil
 }
 
-// LargeDataConverterActivity processes the large payload.
+// CompressionDataConverterActivity processes the large payload.
 // In production, this might involve data transformation, validation, etc.
-func LargeDataConverterActivity(ctx context.Context, input LargePayload) (LargePayload, error) {
+func CompressionDataConverterActivity(ctx context.Context, input LargePayload) (LargePayload, error) {
 	logger := activity.GetLogger(ctx)
 	logger.Info("Large payload activity received input", zap.String("payload_id", input.ID), zap.Int("items_count", len(input.Items)))
 

--- a/new_samples/data/compressed_dataconverter_workflow_test.go
+++ b/new_samples/data/compressed_dataconverter_workflow_test.go
@@ -10,11 +10,11 @@ import (
 	"go.uber.org/cadence/worker"
 )
 
-func Test_LargeDataConverterWorkflow(t *testing.T) {
+func Test_CompressionDataConverterWorkflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
-	env.RegisterWorkflow(LargeDataConverterWorkflow)
-	env.RegisterActivity(LargeDataConverterActivity)
+	env.RegisterWorkflow(CompressionDataConverterWorkflow)
+	env.RegisterActivity(CompressionDataConverterActivity)
 
 	dataConverter := NewCompressedJSONDataConverter()
 	workerOptions := worker.Options{
@@ -28,7 +28,7 @@ func Test_LargeDataConverterWorkflow(t *testing.T) {
 	})
 
 	// Workflow generates its own payload internally, no input needed
-	env.ExecuteWorkflow(LargeDataConverterWorkflow)
+	env.ExecuteWorkflow(CompressionDataConverterWorkflow)
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())

--- a/new_samples/data/encrypted_dataconverter_workflow.go
+++ b/new_samples/data/encrypted_dataconverter_workflow.go
@@ -46,7 +46,10 @@ func NewEncryptedJSONDataConverter(key []byte) encoded.DataConverter {
 var demoEncryptionKey = []byte("cadence-demo-key-NOT-FOR-PROD!!!")
 
 // LoadEncryptionKey reads a 32-byte AES key from the CADENCE_ENCRYPTION_KEY environment
-// variable (hex-encoded, 64 hex chars). Falls back to a hardcoded demo key with a warning.
+// variable (hex-encoded, 64 hex chars). If the env var is unset, falls back to a hardcoded
+// demo key with a warning. If the env var is set but invalid, panics — silently falling back
+// to the public demo key when the user clearly intended their own key would be a security
+// hole.
 func LoadEncryptionKey() []byte {
 	hexKey := os.Getenv("CADENCE_ENCRYPTION_KEY")
 	if hexKey == "" {
@@ -55,9 +58,11 @@ func LoadEncryptionKey() []byte {
 		return demoEncryptionKey
 	}
 	key, err := hex.DecodeString(hexKey)
-	if err != nil || len(key) != 32 {
-		fmt.Printf("WARNING: CADENCE_ENCRYPTION_KEY must be 64 hex chars (32 bytes). Got error: %v. Falling back to demo key.\n", err)
-		return demoEncryptionKey
+	if err != nil {
+		panic(fmt.Sprintf("CADENCE_ENCRYPTION_KEY is not valid hex: %v", err))
+	}
+	if len(key) != 32 {
+		panic(fmt.Sprintf("CADENCE_ENCRYPTION_KEY must be exactly 64 hex chars (32 bytes), got %d hex chars (%d bytes)", len(hexKey), len(key)))
 	}
 	return key
 }

--- a/new_samples/data/encrypted_dataconverter_workflow.go
+++ b/new_samples/data/encrypted_dataconverter_workflow.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,18 +28,20 @@ type encryptedJSONDataConverter struct {
 	gcm cipher.AEAD
 }
 
+var errFailedToCreateConverter = errors.New("failed to create encrypted data converter")
+
 // NewEncryptedJSONDataConverter creates a new encrypted JSON data converter.
-// key must be exactly 32 bytes (AES-256).
-func NewEncryptedJSONDataConverter(key []byte) encoded.DataConverter {
+// key must be exactly 32 bytes (AES-256). Returns an error if the key is invalid.
+func NewEncryptedJSONDataConverter(key []byte) (encoded.DataConverter, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create AES cipher: %v", err))
+		return nil, errors.Join(errFailedToCreateConverter, err)
 	}
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create GCM: %v", err))
+		return nil, errors.Join(errFailedToCreateConverter, err)
 	}
-	return &encryptedJSONDataConverter{gcm: gcm}
+	return &encryptedJSONDataConverter{gcm: gcm}, nil
 }
 
 // demoEncryptionKey is a hardcoded 32-byte key used ONLY when CADENCE_ENCRYPTION_KEY is unset.

--- a/new_samples/data/encrypted_dataconverter_workflow.go
+++ b/new_samples/data/encrypted_dataconverter_workflow.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"time"
+
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/encoded"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+// encryptedJSONDataConverter implements encoded.DataConverter with AES-256-GCM encryption.
+// It serializes data to JSON, then encrypts using AES-256-GCM so that workflow history
+// stored in Cadence is opaque to anyone without the key.
+type encryptedJSONDataConverter struct {
+	gcm cipher.AEAD
+}
+
+// NewEncryptedJSONDataConverter creates a new encrypted JSON data converter.
+// key must be exactly 32 bytes (AES-256).
+func NewEncryptedJSONDataConverter(key []byte) encoded.DataConverter {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create AES cipher: %v", err))
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create GCM: %v", err))
+	}
+	return &encryptedJSONDataConverter{gcm: gcm}
+}
+
+// demoEncryptionKey is a hardcoded 32-byte key used ONLY when CADENCE_ENCRYPTION_KEY is unset.
+// DO NOT use this key in production. Rotate your key and load it from a secrets manager.
+var demoEncryptionKey = []byte("cadence-demo-key-NOT-FOR-PROD!!!")
+
+// LoadEncryptionKey reads a 32-byte AES key from the CADENCE_ENCRYPTION_KEY environment
+// variable (hex-encoded, 64 hex chars). Falls back to a hardcoded demo key with a warning.
+func LoadEncryptionKey() []byte {
+	hexKey := os.Getenv("CADENCE_ENCRYPTION_KEY")
+	if hexKey == "" {
+		fmt.Println("WARNING: CADENCE_ENCRYPTION_KEY not set. Using hardcoded demo key.")
+		fmt.Println("WARNING: DO NOT USE THE DEMO KEY IN PRODUCTION.")
+		return demoEncryptionKey
+	}
+	key, err := hex.DecodeString(hexKey)
+	if err != nil || len(key) != 32 {
+		fmt.Printf("WARNING: CADENCE_ENCRYPTION_KEY must be 64 hex chars (32 bytes). Got error: %v. Falling back to demo key.\n", err)
+		return demoEncryptionKey
+	}
+	return key
+}
+
+func (dc *encryptedJSONDataConverter) ToData(value ...interface{}) ([]byte, error) {
+	var jsonBuf bytes.Buffer
+	enc := json.NewEncoder(&jsonBuf)
+	for i, obj := range value {
+		if err := enc.Encode(obj); err != nil {
+			return nil, fmt.Errorf("unable to encode argument: %d, %v, with error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+
+	nonce := make([]byte, dc.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("unable to generate nonce: %v", err)
+	}
+
+	// Seal appends the GCM authentication tag to the ciphertext.
+	// Output layout: nonce (12 bytes) || ciphertext+tag
+	ciphertext := dc.gcm.Seal(nonce, nonce, jsonBuf.Bytes(), nil)
+	return ciphertext, nil
+}
+
+func (dc *encryptedJSONDataConverter) FromData(input []byte, valuePtr ...interface{}) error {
+	if len(input) == 0 {
+		return nil
+	}
+
+	nonceSize := dc.gcm.NonceSize()
+	if len(input) < nonceSize {
+		return fmt.Errorf("ciphertext too short: %d bytes", len(input))
+	}
+
+	nonce, ciphertext := input[:nonceSize], input[nonceSize:]
+	plaintext, err := dc.gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("decryption failed: %v", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewBuffer(plaintext))
+	for i, obj := range valuePtr {
+		if err := dec.Decode(obj); err != nil {
+			return fmt.Errorf("unable to decode argument: %d, %v, with error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return nil
+}
+
+// SensitiveCustomerRecord represents PII/PHI data that must be encrypted in workflow history.
+type SensitiveCustomerRecord struct {
+	CustomerID    string `json:"customer_id"`
+	FullName      string `json:"full_name"`
+	Email         string `json:"email"`
+	SSN           string `json:"ssn"`
+	CreditCard    string `json:"credit_card_number"`
+	BillingAddr   string `json:"billing_address"`
+	MedicalNotes  string `json:"medical_notes"`
+	DiagnosisCode string `json:"diagnosis_code"`
+	Prescriptions string `json:"prescriptions"`
+	InsuranceID   string `json:"insurance_id"`
+	ProcessedBy   string `json:"processed_by"`
+}
+
+// CreateSensitiveCustomerRecord creates a sample customer record with realistic PII/PHI.
+func CreateSensitiveCustomerRecord() SensitiveCustomerRecord {
+	return SensitiveCustomerRecord{
+		CustomerID:    "cust_8a7f3b2e",
+		FullName:      "Jane A. Doe",
+		Email:         "jane.doe@example.com",
+		SSN:           "123-45-6789",
+		CreditCard:    "4111-1111-1111-1111",
+		BillingAddr:   "1234 Elm Street, Springfield, IL 62701",
+		MedicalNotes:  "Patient presents with hypertension and type-2 diabetes. Advised dietary changes and increased physical activity. Follow-up scheduled in 3 months.",
+		DiagnosisCode: "I10, E11.9",
+		Prescriptions: "Lisinopril 10mg once daily; Metformin 500mg twice daily",
+		InsuranceID:   "INS-987654321",
+		ProcessedBy:   "workflow-processor-v2",
+	}
+}
+
+// GetEncryptionSizeInfo returns the plaintext size, ciphertext size, and a hex preview of the ciphertext.
+func GetEncryptionSizeInfo(record SensitiveCustomerRecord, converter encoded.DataConverter) (int, int, string, error) {
+	jsonData, err := json.Marshal(record)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("failed to marshal record: %v", err)
+	}
+	plaintextSize := len(jsonData)
+
+	encrypted, err := converter.ToData(record)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("failed to encrypt record: %v", err)
+	}
+	ciphertextSize := len(encrypted)
+
+	preview := hex.EncodeToString(encrypted)
+	if len(preview) > 80 {
+		preview = preview[:80] + "..."
+	}
+
+	return plaintextSize, ciphertextSize, preview, nil
+}
+
+// EncryptionDataConverterWorkflow demonstrates encrypting sensitive workflow data.
+// The DataConverter automatically encrypts all workflow inputs, outputs, and activity
+// parameters before they are stored in Cadence history. Without the key, the data
+// is unreadable even to Cadence operators viewing the workflow history.
+//
+// Note: The workflow generates its own payload internally so it can be started from
+// the Cadence CLI without requiring the CLI to use the custom DataConverter.
+func EncryptionDataConverterWorkflow(ctx workflow.Context) (SensitiveCustomerRecord, error) {
+	logger := workflow.GetLogger(ctx)
+
+	record := CreateSensitiveCustomerRecord()
+	logger.Info("Encryption workflow started", zap.String("customer_id", record.CustomerID))
+	logger.Info("All customer PII/PHI will be encrypted before storage in Cadence history")
+
+	activityOptions := workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	var result SensitiveCustomerRecord
+	err := workflow.ExecuteActivity(ctx, EncryptionDataConverterActivity, record).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Encryption workflow activity failed", zap.Error(err))
+		return SensitiveCustomerRecord{}, err
+	}
+
+	logger.Info("Encryption workflow completed", zap.String("customer_id", result.CustomerID))
+	logger.Info("Note: All PII/PHI was automatically encrypted/decrypted using AES-256-GCM")
+	return result, nil
+}
+
+// EncryptionDataConverterActivity processes the sensitive customer record.
+// In production this might perform claims processing, fraud checks, etc.
+func EncryptionDataConverterActivity(ctx context.Context, record SensitiveCustomerRecord) (SensitiveCustomerRecord, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Encryption activity received record", zap.String("customer_id", record.CustomerID))
+
+	record.ProcessedBy = record.ProcessedBy + " (Encrypted)"
+
+	logger.Info("Encryption activity completed", zap.String("customer_id", record.CustomerID))
+	return record, nil
+}

--- a/new_samples/data/encrypted_dataconverter_workflow_test.go
+++ b/new_samples/data/encrypted_dataconverter_workflow_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/encoded"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+)
+
+func Test_EncryptionDataConverterWorkflow(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(EncryptionDataConverterWorkflow)
+	env.RegisterActivity(EncryptionDataConverterActivity)
+
+	dataConverter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	workerOptions := worker.Options{
+		DataConverter: dataConverter,
+	}
+	env.SetWorkerOptions(workerOptions)
+
+	var activityResult SensitiveCustomerRecord
+	env.SetOnActivityCompletedListener(func(activityInfo *activity.Info, result encoded.Value, err error) {
+		result.Get(&activityResult)
+	})
+
+	// Workflow generates its own payload internally, no input needed
+	env.ExecuteWorkflow(EncryptionDataConverterWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "cust_8a7f3b2e", activityResult.CustomerID)
+	require.Equal(t, "workflow-processor-v2 (Encrypted)", activityResult.ProcessedBy)
+}
+
+func Test_EncryptionRoundTrip(t *testing.T) {
+	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+
+	original := CreateSensitiveCustomerRecord()
+	encrypted, err := converter.ToData(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encrypted)
+
+	var decoded SensitiveCustomerRecord
+	err = converter.FromData(encrypted, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, original.SSN, decoded.SSN)
+	require.Equal(t, original.CreditCard, decoded.CreditCard)
+	require.Equal(t, original.MedicalNotes, decoded.MedicalNotes)
+}
+
+func Test_EncryptionDifferentEachTime(t *testing.T) {
+	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	record := CreateSensitiveCustomerRecord()
+
+	enc1, err := converter.ToData(record)
+	require.NoError(t, err)
+	enc2, err := converter.ToData(record)
+	require.NoError(t, err)
+
+	// Each encryption produces a different ciphertext due to random nonce
+	require.NotEqual(t, enc1, enc2)
+}

--- a/new_samples/data/encrypted_dataconverter_workflow_test.go
+++ b/new_samples/data/encrypted_dataconverter_workflow_test.go
@@ -16,7 +16,8 @@ func Test_EncryptionDataConverterWorkflow(t *testing.T) {
 	env.RegisterWorkflow(EncryptionDataConverterWorkflow)
 	env.RegisterActivity(EncryptionDataConverterActivity)
 
-	dataConverter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	dataConverter, err := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	require.NoError(t, err)
 	workerOptions := worker.Options{
 		DataConverter: dataConverter,
 	}
@@ -37,7 +38,8 @@ func Test_EncryptionDataConverterWorkflow(t *testing.T) {
 }
 
 func Test_EncryptionRoundTrip(t *testing.T) {
-	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	converter, err := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	require.NoError(t, err)
 
 	original := CreateSensitiveCustomerRecord()
 	encrypted, err := converter.ToData(original)
@@ -53,7 +55,8 @@ func Test_EncryptionRoundTrip(t *testing.T) {
 }
 
 func Test_EncryptionDifferentEachTime(t *testing.T) {
-	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	converter, err := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	require.NoError(t, err)
 	record := CreateSensitiveCustomerRecord()
 
 	enc1, err := converter.ToData(record)
@@ -63,4 +66,10 @@ func Test_EncryptionDifferentEachTime(t *testing.T) {
 
 	// Each encryption produces a different ciphertext due to random nonce
 	require.NotEqual(t, enc1, enc2)
+}
+
+func Test_NewEncryptedJSONDataConverter_InvalidKey(t *testing.T) {
+	_, err := NewEncryptedJSONDataConverter([]byte("too-short"))
+	require.Error(t, err)
+	require.ErrorIs(t, err, errFailedToCreateConverter)
 }

--- a/new_samples/data/generator/README_specific.md
+++ b/new_samples/data/generator/README_specific.md
@@ -90,7 +90,7 @@ cadence --domain cadence-samples \
 
 #### How it works
 
-- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a UUID key and return `0x01 || {"__s3_ref":"<bucket>/<uuid>"}`. Otherwise return `0x00 || json` inline.
+- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a SHA-256 key and return `0x01 || {"__s3_ref":"<bucket>/<sha256hex>"}`. Otherwise return `0x00 || json` inline.
 - `FromData`: read prefix byte → if `0x01`, fetch from `BlobStore` and decode; if `0x00`, decode inline.
 
 #### Default store (zero-config)

--- a/new_samples/data/generator/README_specific.md
+++ b/new_samples/data/generator/README_specific.md
@@ -1,63 +1,127 @@
-## Samples in this folder
+## Data Converter Samples
 
-This folder contains samples demonstrating custom data conversion patterns in Cadence.
+This folder demonstrates three production-ready patterns for custom `DataConverter` implementations in Cadence. A `DataConverter` controls how every workflow input, output, and activity parameter is serialized before it is written to Cadence history — making it the right place to add compression, encryption, or external offloading without changing any workflow or activity code.
 
-### Data Converter Workflow
+### What is a DataConverter?
 
-The `LargeDataConverterWorkflow` demonstrates how to use custom data converters with compression capabilities. Data converters control how workflow inputs, outputs, and activity parameters are serialized and deserialized.
+A `DataConverter` implements two methods:
 
-#### What is a DataConverter?
+- `ToData(value ...interface{}) ([]byte, error)` — called before data is written to Cadence history
+- `FromData(input []byte, valuePtr ...interface{}) error` — called when data is read back
 
-A `DataConverter` is responsible for:
-- Serializing workflow inputs and activity parameters before storage
-- Deserializing workflow outputs and activity results when retrieved
-- Enabling custom encoding formats (compression, encryption, etc.)
+The same `DataConverter` must be used by **both the worker and any client that triggers or queries the workflow**. In this sample the workflows generate their own payloads internally, so they can be started from the Cadence CLI without bundling a custom converter into the CLI itself.
 
-#### The Compressed JSON DataConverter
+Each sample runs its own worker on its own task list so it can use its own `DataConverter`. Start all three with a single `go run .`.
 
-This sample implements `compressedJSONDataConverter` which:
-- Serializes data to JSON format
-- Compresses using gzip to reduce storage size
-- Automatically decompresses when reading data back
+---
 
-#### Compression Benefits
+### Compression Sample
 
-For large payloads, compression typically provides:
-- **60-80% size reduction** for JSON data
-- **Lower storage costs** in Cadence history
-- **Reduced bandwidth** for data transfer
-- **Better scalability** with large payloads
+`CompressionDataConverterWorkflow` demonstrates gzip-over-JSON compression. For repetitive JSON data this typically achieves 60–80% size reduction, lowering storage costs and bandwidth for large workflow payloads.
 
-#### Use Cases
-
-Custom DataConverters are useful when you need to:
-- Reduce storage costs with compression
-- Add encryption/decryption for sensitive data
-- Support legacy serialization formats
-- Implement custom compression algorithms (LZ4, Snappy, etc.)
-- Add data validation during serialization
-
-#### How to Start the Workflow
+**Task list:** `cadence-samples-data-compression`
 
 ```bash
 cadence --domain cadence-samples \
   workflow start \
-  --workflow_type cadence_samples.LargeDataConverterWorkflow \
-  --tl cadence-samples-worker \
+  --workflow_type cadence_samples.CompressionDataConverterWorkflow \
+  --tl cadence-samples-data-compression \
   --et 60
 ```
 
-Note: The workflow generates its own large payload internally - no input is required. This design allows the workflow to be started from CLI without the client needing the custom DataConverter. The compression demonstration happens when data is passed between the workflow and activity. When the worker starts, it displays compression statistics showing the before/after sizes.
+When the worker starts it prints a compression statistics banner showing the before/after sizes of the sample payload so you can see the benefit immediately.
 
-#### Key Implementation Details
+---
 
-The custom DataConverter is configured in `worker.go`:
+### Encryption Sample
 
-```go
-workerOptions := worker.Options{
-    DataConverter: NewCompressedJSONDataConverter(),
-    // ... other options
-}
+`EncryptionDataConverterWorkflow` demonstrates AES-256-GCM encryption. Every workflow input, output, and activity parameter is encrypted before being written to Cadence history. Without the key, the data stored by the Cadence server — including any operators browsing workflow history — is completely opaque.
+
+The sample uses a `SensitiveCustomerRecord` containing realistic PII and PHI fields (name, email, SSN, credit card, medical notes) to make the use case concrete.
+
+**Task list:** `cadence-samples-data-encryption`
+
+```bash
+cadence --domain cadence-samples \
+  workflow start \
+  --workflow_type cadence_samples.EncryptionDataConverterWorkflow \
+  --tl cadence-samples-data-encryption \
+  --et 60
 ```
 
-Both the worker AND any client triggering workflows must use the same DataConverter to properly encode/decode data.
+#### Encryption key
+
+By default, the worker uses a hardcoded demo key and prints a prominent warning. To use your own key:
+
+```bash
+# Generate a random 32-byte (256-bit) key
+export CADENCE_ENCRYPTION_KEY=$(openssl rand -hex 32)
+go run .
+```
+
+> **WARNING:** The hardcoded demo key (`cadence-demo-key-NOT-FOR-PROD!!!`) is public.
+> Never use it in production. In production, load your key from a secrets manager
+> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.) and rotate it regularly.
+
+#### How AES-256-GCM works
+
+- `ToData`: JSON-encode arguments → generate a 12-byte random nonce → `cipher.AEAD.Seal` → return `nonce || ciphertext+tag`.
+- `FromData`: split nonce from input → `cipher.AEAD.Open` → JSON-decode.
+
+The GCM authentication tag (16 bytes) ensures ciphertext tampering is detected. The random nonce means the same plaintext produces different ciphertext on every call, preventing replay detection by an attacker who observes Cadence history.
+
+---
+
+### S3 Offload Sample (Claim-Check Pattern)
+
+`S3OffloadDataConverterWorkflow` demonstrates the *claim-check* pattern: payloads larger than a configurable threshold are stored in an external `BlobStore` and only a small reference (a few dozen bytes) travels through Cadence workflow history.
+
+This solves the practical problem of Cadence's per-payload size limits (~2 MB) for workflows that must pass very large datasets between the workflow and its activities.
+
+**Task list:** `cadence-samples-data-s3`
+
+```bash
+cadence --domain cadence-samples \
+  workflow start \
+  --workflow_type cadence_samples.S3OffloadDataConverterWorkflow \
+  --tl cadence-samples-data-s3 \
+  --et 60
+```
+
+#### How it works
+
+- `ToData`: JSON-encode → if `len(json) > thresholdBytes`, upload to `BlobStore` under a UUID key and return `0x01 || {"__s3_ref":"<bucket>/<uuid>"}`. Otherwise return `0x00 || json` inline.
+- `FromData`: read prefix byte → if `0x01`, fetch from `BlobStore` and decode; if `0x00`, decode inline.
+
+#### Default store (zero-config)
+
+Out of the box, `localFSBlobStore` writes blobs to `os.TempDir()/cadence-samples-data-s3/`. No cloud credentials or additional dependencies are needed.
+
+#### Swapping in real AWS S3
+
+The file `s3_dataconverter_workflow.go` contains a commented `s3BlobStore` stub showing the exact AWS SDK calls needed. To enable it:
+
+1. Add the AWS SDK to your module:
+   ```bash
+   go get github.com/aws/aws-sdk-go-v2/config
+   go get github.com/aws/aws-sdk-go-v2/service/s3
+   ```
+2. Uncomment the `s3BlobStore` section in `s3_dataconverter_workflow.go`.
+3. Replace `NewLocalFSBlobStore()` with `NewS3BlobStore(bucket, region)` in `worker.go`.
+4. Set standard AWS environment variables (`AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or use an IAM instance role.
+
+You can also point the SDK at [LocalStack](https://localstack.cloud/) or [MinIO](https://min.io/) for local testing without a real AWS account.
+
+> **Note on cleanup:** The `s3OffloadDataConverter` does not delete blobs after the workflow completes. In production, use S3 object lifecycle policies to automatically expire old blobs.
+
+---
+
+### When to use which pattern
+
+| Pattern | Best for |
+|---------|----------|
+| **Compression** | Large repetitive JSON payloads; reducing storage cost without confidentiality requirements |
+| **Encryption** | PII, PHI, secrets, or any data that must be unreadable in Cadence history |
+| **S3 Offload** | Payloads approaching Cadence's size limits; binary or non-JSON data; cost-conscious archival |
+
+Patterns can be composed: encrypt-then-compress, or encrypt-then-offload to S3 for maximum security and minimum history size.

--- a/new_samples/data/generator/README_specific.md
+++ b/new_samples/data/generator/README_specific.md
@@ -61,7 +61,7 @@ go run .
 
 > **WARNING:** The hardcoded demo key (`cadence-demo-key-NOT-FOR-PROD!!!`) is public.
 > Never use it in production. In production, load your key from a secrets manager
-> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.) and rotate it regularly.
+> (AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, etc.).
 
 #### How AES-256-GCM works
 

--- a/new_samples/data/generator/generate.go
+++ b/new_samples/data/generator/generate.go
@@ -3,16 +3,27 @@ package main
 import "github.com/uber-common/cadence-samples/new_samples/template"
 
 func main() {
-	// Define the data for Data samples
-	// Note: worker.go is hand-written (not generated) because this sample
-	// requires a custom DataConverter in worker options
+	// Define the data for Data samples.
+	// NOTE: worker.go is hand-written (not generated) because each sample
+	// requires its own DataConverter in worker options. We call the individual
+	// generation functions explicitly instead of template.GenerateAll so the
+	// hand-written worker.go is never clobbered.
 	data := template.TemplateData{
 		SampleName: "Data",
-		Workflows:  []string{"LargeDataConverterWorkflow"},
-		Activities: []string{"LargeDataConverterActivity"},
+		Workflows: []string{
+			"CompressionDataConverterWorkflow",
+			"EncryptionDataConverterWorkflow",
+			"S3OffloadDataConverterWorkflow",
+		},
+		Activities: []string{
+			"CompressionDataConverterActivity",
+			"EncryptionDataConverterActivity",
+			"S3OffloadDataConverterActivity",
+		},
 	}
 
-	template.GenerateAll(data)
+	// Explicitly skip GenerateWorker — worker.go is maintained by hand.
+	template.GenerateMain(data)
+	template.GenerateSampleReadMe(data)
+	template.GenerateGeneratorReadMe(data)
 }
-
-// Implement custom generator below

--- a/new_samples/data/s3_dataconverter_workflow.go
+++ b/new_samples/data/s3_dataconverter_workflow.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/encoded"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+// BlobStore is an abstraction over any external object store (local filesystem, S3, GCS, etc.).
+// The s3OffloadDataConverter uses this interface to store large payloads outside Cadence history.
+type BlobStore interface {
+	Put(ctx context.Context, key string, data []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+}
+
+// localFSBlobStore implements BlobStore using the local filesystem.
+// It is the default zero-config implementation used when running this demo without real AWS.
+// Files are written under os.TempDir()/cadence-samples-data-s3/.
+type localFSBlobStore struct {
+	baseDir string
+}
+
+// NewLocalFSBlobStore creates a local filesystem blob store under os.TempDir().
+func NewLocalFSBlobStore() BlobStore {
+	baseDir := filepath.Join(os.TempDir(), "cadence-samples-data-s3")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		panic(fmt.Sprintf("failed to create blob store dir %s: %v", baseDir, err))
+	}
+	return &localFSBlobStore{baseDir: baseDir}
+}
+
+func (s *localFSBlobStore) Put(_ context.Context, key string, data []byte) error {
+	// Sanitize key to avoid directory traversal
+	safeKey := strings.ReplaceAll(key, "/", "_")
+	path := filepath.Join(s.baseDir, safeKey)
+	return os.WriteFile(path, data, 0o644)
+}
+
+func (s *localFSBlobStore) Get(_ context.Context, key string) ([]byte, error) {
+	safeKey := strings.ReplaceAll(key, "/", "_")
+	path := filepath.Join(s.baseDir, safeKey)
+	return os.ReadFile(path)
+}
+
+// =============================================================================
+// S3 BlobStore stub
+//
+// To use a real AWS S3 bucket instead of the local filesystem:
+//  1. Add aws-sdk-go-v2 to go.mod:
+//       go get github.com/aws/aws-sdk-go-v2/config
+//       go get github.com/aws/aws-sdk-go-v2/service/s3
+//  2. Uncomment and compile the s3BlobStore implementation below.
+//  3. Replace NewLocalFSBlobStore() with NewS3BlobStore(bucket, region) in worker.go.
+//  4. Set AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (or use an instance role).
+//
+// /*
+// import (
+//     "github.com/aws/aws-sdk-go-v2/aws"
+//     awsconfig "github.com/aws/aws-sdk-go-v2/config"
+//     "github.com/aws/aws-sdk-go-v2/service/s3"
+// )
+//
+// type s3BlobStore struct {
+//     client *s3.Client
+//     bucket string
+// }
+//
+// func NewS3BlobStore(bucket, region string) BlobStore {
+//     cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
+//     if err != nil {
+//         panic("failed to load AWS config: " + err.Error())
+//     }
+//     return &s3BlobStore{client: s3.NewFromConfig(cfg), bucket: bucket}
+// }
+//
+// func (s *s3BlobStore) Put(ctx context.Context, key string, data []byte) error {
+//     _, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+//         Bucket: aws.String(s.bucket),
+//         Key:    aws.String(key),
+//         Body:   bytes.NewReader(data),
+//     })
+//     return err
+// }
+//
+// func (s *s3BlobStore) Get(ctx context.Context, key string) ([]byte, error) {
+//     out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+//         Bucket: aws.String(s.bucket),
+//         Key:    aws.String(key),
+//     })
+//     if err != nil {
+//         return nil, err
+//     }
+//     defer out.Body.Close()
+//     return io.ReadAll(out.Body)
+// }
+// */
+// =============================================================================
+
+// s3Envelope is the small reference stored in Cadence history when a payload is offloaded.
+type s3Envelope struct {
+	S3Ref string `json:"__s3_ref"`
+}
+
+const (
+	// inlinePrefix is prepended to inline (below-threshold) payloads so FromData can distinguish them.
+	inlinePrefix = byte(0x00)
+	// offloadPrefix is prepended to offloaded payloads.
+	offloadPrefix = byte(0x01)
+	// defaultThresholdBytes: payloads larger than this are offloaded to the BlobStore.
+	// Cadence's default max payload size is ~2MB; this threshold is set intentionally low
+	// so the demo workflow comfortably triggers offloading.
+	defaultThresholdBytes = 4096 // 4 KB
+)
+
+// s3OffloadDataConverter implements the claim-check pattern:
+// large payloads are stored in BlobStore; only a small reference travels through Cadence history.
+type s3OffloadDataConverter struct {
+	store          BlobStore
+	bucket         string
+	thresholdBytes int
+}
+
+// NewS3OffloadDataConverter creates a new s3OffloadDataConverter.
+// store is the BlobStore backend (use NewLocalFSBlobStore() for zero-config demo).
+// bucket is a logical bucket/prefix name embedded in the reference key.
+// thresholdBytes is the max inline payload size; larger payloads are offloaded.
+func NewS3OffloadDataConverter(store BlobStore, bucket string, thresholdBytes int) encoded.DataConverter {
+	return &s3OffloadDataConverter{
+		store:          store,
+		bucket:         bucket,
+		thresholdBytes: thresholdBytes,
+	}
+}
+
+func (dc *s3OffloadDataConverter) ToData(value ...interface{}) ([]byte, error) {
+	var jsonBuf bytes.Buffer
+	enc := json.NewEncoder(&jsonBuf)
+	for i, obj := range value {
+		if err := enc.Encode(obj); err != nil {
+			return nil, fmt.Errorf("unable to encode argument: %d, %v, with error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	jsonBytes := jsonBuf.Bytes()
+
+	if len(jsonBytes) <= dc.thresholdBytes {
+		// Small payload: store inline with a prefix marker
+		result := make([]byte, 1+len(jsonBytes))
+		result[0] = inlinePrefix
+		copy(result[1:], jsonBytes)
+		return result, nil
+	}
+
+	// Large payload: offload to blob store, store only a reference in Cadence history
+	key := fmt.Sprintf("%s/%s", dc.bucket, uuid.New().String())
+	if err := dc.store.Put(context.Background(), key, jsonBytes); err != nil {
+		return nil, fmt.Errorf("failed to offload payload to blob store (key=%s): %v", key, err)
+	}
+
+	envelope, err := json.Marshal(s3Envelope{S3Ref: key})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal s3 envelope: %v", err)
+	}
+
+	result := make([]byte, 1+len(envelope))
+	result[0] = offloadPrefix
+	copy(result[1:], envelope)
+	return result, nil
+}
+
+func (dc *s3OffloadDataConverter) FromData(input []byte, valuePtr ...interface{}) error {
+	// Empty input: workflow was started without arguments (e.g., from CLI without --input).
+	if len(input) == 0 {
+		return nil
+	}
+
+	prefix, payload := input[0], input[1:]
+
+	var jsonData []byte
+	switch prefix {
+	case inlinePrefix:
+		// Empty payload means zero arguments were encoded (e.g., no workflow input).
+		if len(payload) == 0 {
+			return nil
+		}
+		jsonData = payload
+	case offloadPrefix:
+		var envelope s3Envelope
+		if err := json.Unmarshal(payload, &envelope); err != nil {
+			return fmt.Errorf("s3 offload: failed to unmarshal envelope: %v", err)
+		}
+		fetched, err := dc.store.Get(context.Background(), envelope.S3Ref)
+		if err != nil {
+			return fmt.Errorf("s3 offload: failed to fetch payload from blob store (key=%s): %v", envelope.S3Ref, err)
+		}
+		jsonData = fetched
+	default:
+		return fmt.Errorf("s3 offload: unknown prefix byte 0x%02x", prefix)
+	}
+
+	dec := json.NewDecoder(bytes.NewBuffer(jsonData))
+	for i, obj := range valuePtr {
+		if err := dec.Decode(obj); err != nil {
+			return fmt.Errorf("unable to decode argument: %d, %v, with error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return nil
+}
+
+// S3LargePayload is a sizable data structure used to demonstrate S3 offloading.
+// It is intentionally larger than defaultThresholdBytes so every workflow execution
+// triggers an offload to the BlobStore.
+type S3LargePayload struct {
+	JobID       string            `json:"job_id"`
+	Description string            `json:"description"`
+	DataPoints  []S3DataPoint     `json:"data_points"`
+	Metadata    map[string]string `json:"metadata"`
+	ProcessedBy string            `json:"processed_by"`
+}
+
+// S3DataPoint represents a single telemetry measurement.
+type S3DataPoint struct {
+	Timestamp string  `json:"timestamp"`
+	Metric    string  `json:"metric"`
+	Value     float64 `json:"value"`
+	Tags      string  `json:"tags"`
+}
+
+// CreateS3LargePayload creates a sample payload well above defaultThresholdBytes.
+func CreateS3LargePayload() S3LargePayload {
+	points := make([]S3DataPoint, 200)
+	for i := range points {
+		points[i] = S3DataPoint{
+			Timestamp: fmt.Sprintf("2024-01-15T%02d:30:00Z", i%24),
+			Metric:    fmt.Sprintf("telemetry.sensor_%03d.temperature", i),
+			Value:     20.0 + float64(i%30)/10.0,
+			Tags:      fmt.Sprintf("region=us-east-1,host=node-%03d,env=production", i%10),
+		}
+	}
+
+	meta := make(map[string]string)
+	for i := 0; i < 20; i++ {
+		meta[fmt.Sprintf("batch_key_%02d", i)] = strings.Repeat("value-data-", 5)
+	}
+
+	return S3LargePayload{
+		JobID:       "batch-job-20240115-001",
+		Description: strings.Repeat("Large telemetry batch job containing sensor readings from the production cluster. ", 10),
+		DataPoints:  points,
+		Metadata:    meta,
+		ProcessedBy: "s3-offload-worker-v1",
+	}
+}
+
+// GetS3OffloadSizeInfo returns the JSON size, what is stored externally, and what travels through Cadence.
+func GetS3OffloadSizeInfo(payload S3LargePayload, thresholdBytes int) (int, int, error) {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to marshal payload: %v", err)
+	}
+	jsonSize := len(jsonData)
+
+	// The Cadence history reference is: 1 prefix byte + JSON envelope {"__s3_ref":"<bucket>/<uuid>"}
+	// A UUID is 36 chars; bucket + "/" + UUID ≈ bucket + 37 chars
+	sampleEnvelope, _ := json.Marshal(s3Envelope{S3Ref: "cadence-samples-data-s3/" + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"})
+	cadenceBytes := 1 + len(sampleEnvelope)
+
+	return jsonSize, cadenceBytes, nil
+}
+
+// S3OffloadDataConverterWorkflow demonstrates the claim-check pattern with a BlobStore.
+// Payloads larger than the threshold are stored externally; only a small reference is
+// kept in Cadence workflow history, dramatically reducing history storage requirements.
+//
+// Note: The workflow generates its own payload internally so it can be started from
+// the Cadence CLI without requiring the CLI to use the custom DataConverter.
+func S3OffloadDataConverterWorkflow(ctx workflow.Context) (S3LargePayload, error) {
+	logger := workflow.GetLogger(ctx)
+
+	payload := CreateS3LargePayload()
+	logger.Info("S3 offload workflow started",
+		zap.String("job_id", payload.JobID),
+		zap.Int("data_points", len(payload.DataPoints)))
+	logger.Info("Large payload will be offloaded to BlobStore; only a reference travels through Cadence history")
+
+	activityOptions := workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	var result S3LargePayload
+	err := workflow.ExecuteActivity(ctx, S3OffloadDataConverterActivity, payload).Get(ctx, &result)
+	if err != nil {
+		logger.Error("S3 offload workflow activity failed", zap.Error(err))
+		return S3LargePayload{}, err
+	}
+
+	logger.Info("S3 offload workflow completed", zap.String("job_id", result.JobID))
+	logger.Info("Note: Large payload was transparently offloaded and retrieved via the BlobStore")
+	return result, nil
+}
+
+// S3OffloadDataConverterActivity processes the large payload retrieved from the BlobStore.
+// From the activity's perspective the DataConverter is invisible — it receives the full
+// deserialized struct just as it would with any other DataConverter.
+func S3OffloadDataConverterActivity(ctx context.Context, payload S3LargePayload) (S3LargePayload, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("S3 offload activity received payload",
+		zap.String("job_id", payload.JobID),
+		zap.Int("data_points", len(payload.DataPoints)))
+
+	payload.ProcessedBy = payload.ProcessedBy + " (Processed)"
+
+	logger.Info("S3 offload activity completed", zap.String("job_id", payload.JobID))
+	return payload, nil
+}

--- a/new_samples/data/s3_dataconverter_workflow.go
+++ b/new_samples/data/s3_dataconverter_workflow.go
@@ -282,8 +282,8 @@ func GetS3OffloadSizeInfo(payload S3LargePayload, thresholdBytes int) (int, int,
 	jsonSize := len(jsonData)
 
 	// The Cadence history reference is: 1 prefix byte + JSON envelope {"__s3_ref":"<bucket>/<sha256hex>"}
-	// A UUID is 36 chars; bucket + "/" + UUID ≈ bucket + 37 chars
-	sampleEnvelope, _ := json.Marshal(s3Envelope{S3Ref: "cadence-samples-data-s3/" + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"})
+	// A SHA-256 hex digest is 64 chars; bucket + "/" + hex ≈ bucket + 65 chars
+	sampleEnvelope, _ := json.Marshal(s3Envelope{S3Ref: "cadence-samples-data-s3/" + strings.Repeat("a", 64)})
 	cadenceBytes := 1 + len(sampleEnvelope)
 
 	return jsonSize, cadenceBytes, nil

--- a/new_samples/data/s3_dataconverter_workflow.go
+++ b/new_samples/data/s3_dataconverter_workflow.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/workflow"
@@ -41,7 +41,7 @@ func NewLocalFSBlobStore() BlobStore {
 	return &localFSBlobStore{baseDir: baseDir}
 }
 
-// sanitizeKey turns a "bucket/uuid" key into a single safe filename. Keys are always
+// sanitizeKey turns a "bucket/sha256hex" key into a single safe filename. Keys are always
 // generated internally by the DataConverter, but filepath.Base provides a belt-and-suspenders
 // guarantee against directory traversal in case a future caller passes a user-controlled key.
 func sanitizeKey(key string) string {
@@ -166,8 +166,14 @@ func (dc *s3OffloadDataConverter) ToData(value ...interface{}) ([]byte, error) {
 		return result, nil
 	}
 
-	// Large payload: offload to blob store, store only a reference in Cadence history
-	key := fmt.Sprintf("%s/%s", dc.bucket, uuid.New().String())
+	// Derive the key from the SHA-256 of the payload so ToData is idempotent across
+	// Cadence workflow replays. Using uuid.New() here would write a new orphaned blob
+	// on every replay because the SDK calls ToData again each time the workflow is
+	// re-executed from the top. If the workflow needs to control the key (e.g. to
+	// encode routing metadata), generate it with workflow.SideEffect and pass it
+	// alongside the payload instead.
+	hash := sha256.Sum256(jsonBytes)
+	key := fmt.Sprintf("%s/%x", dc.bucket, hash)
 	if err := dc.store.Put(context.Background(), key, jsonBytes); err != nil {
 		return nil, fmt.Errorf("failed to offload payload to blob store (key=%s): %v", key, err)
 	}
@@ -275,7 +281,7 @@ func GetS3OffloadSizeInfo(payload S3LargePayload, thresholdBytes int) (int, int,
 	}
 	jsonSize := len(jsonData)
 
-	// The Cadence history reference is: 1 prefix byte + JSON envelope {"__s3_ref":"<bucket>/<uuid>"}
+	// The Cadence history reference is: 1 prefix byte + JSON envelope {"__s3_ref":"<bucket>/<sha256hex>"}
 	// A UUID is 36 chars; bucket + "/" + UUID ≈ bucket + 37 chars
 	sampleEnvelope, _ := json.Marshal(s3Envelope{S3Ref: "cadence-samples-data-s3/" + "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"})
 	cadenceBytes := 1 + len(sampleEnvelope)

--- a/new_samples/data/s3_dataconverter_workflow.go
+++ b/new_samples/data/s3_dataconverter_workflow.go
@@ -41,16 +41,20 @@ func NewLocalFSBlobStore() BlobStore {
 	return &localFSBlobStore{baseDir: baseDir}
 }
 
+// sanitizeKey turns a "bucket/uuid" key into a single safe filename. Keys are always
+// generated internally by the DataConverter, but filepath.Base provides a belt-and-suspenders
+// guarantee against directory traversal in case a future caller passes a user-controlled key.
+func sanitizeKey(key string) string {
+	return filepath.Base(strings.ReplaceAll(key, "/", "_"))
+}
+
 func (s *localFSBlobStore) Put(_ context.Context, key string, data []byte) error {
-	// Sanitize key to avoid directory traversal
-	safeKey := strings.ReplaceAll(key, "/", "_")
-	path := filepath.Join(s.baseDir, safeKey)
+	path := filepath.Join(s.baseDir, sanitizeKey(key))
 	return os.WriteFile(path, data, 0o644)
 }
 
 func (s *localFSBlobStore) Get(_ context.Context, key string) ([]byte, error) {
-	safeKey := strings.ReplaceAll(key, "/", "_")
-	path := filepath.Join(s.baseDir, safeKey)
+	path := filepath.Join(s.baseDir, sanitizeKey(key))
 	return os.ReadFile(path)
 }
 

--- a/new_samples/data/s3_dataconverter_workflow_test.go
+++ b/new_samples/data/s3_dataconverter_workflow_test.go
@@ -87,6 +87,33 @@ func Test_S3OffloadRoundTrip(t *testing.T) {
 	require.Equal(t, len(original.DataPoints), len(decoded.DataPoints))
 }
 
+func Test_S3ReplayIdempotent(t *testing.T) {
+	// Simulate Cadence replay: ToData is called multiple times on the same payload.
+	// Each call must produce an identical encoded output and write to the same blob key,
+	// not create new orphaned blobs on every replay.
+	store := newMemoryBlobStore()
+	converter := NewS3OffloadDataConverter(store, "test-bucket", defaultThresholdBytes)
+
+	payload := CreateS3LargePayload()
+
+	enc1, err := converter.ToData(payload)
+	require.NoError(t, err)
+	require.Equal(t, offloadPrefix, enc1[0], "expected offload prefix for large payload")
+
+	enc2, err := converter.ToData(payload)
+	require.NoError(t, err)
+
+	// Both calls must return byte-for-byte identical output (same key in the envelope).
+	require.Equal(t, enc1, enc2, "ToData must be idempotent across replays — same payload must produce same encoded bytes")
+
+	// The store must contain exactly one entry, not two.
+	mstore := store.(*memoryBlobStore)
+	mstore.mu.RLock()
+	blobCount := len(mstore.data)
+	mstore.mu.RUnlock()
+	require.Equal(t, 1, blobCount, "replayed ToData calls must overwrite the same blob key, not create new orphaned entries")
+}
+
 func Test_S3InlineSmallPayload(t *testing.T) {
 	store := newMemoryBlobStore()
 	converter := NewS3OffloadDataConverter(store, "test-bucket", 100000) // very high threshold

--- a/new_samples/data/s3_dataconverter_workflow_test.go
+++ b/new_samples/data/s3_dataconverter_workflow_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/encoded"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+)
+
+// memoryBlobStore is an in-memory BlobStore used in tests to avoid filesystem I/O.
+type memoryBlobStore struct {
+	mu   sync.RWMutex
+	data map[string][]byte
+}
+
+func newMemoryBlobStore() BlobStore {
+	return &memoryBlobStore{data: make(map[string][]byte)}
+}
+
+func (m *memoryBlobStore) Put(_ context.Context, key string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (m *memoryBlobStore) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	d, ok := m.data[key]
+	if !ok {
+		return nil, nil
+	}
+	return append([]byte(nil), d...), nil
+}
+
+func Test_S3OffloadDataConverterWorkflow(t *testing.T) {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(S3OffloadDataConverterWorkflow)
+	env.RegisterActivity(S3OffloadDataConverterActivity)
+
+	store := newMemoryBlobStore()
+	dataConverter := NewS3OffloadDataConverter(store, "test-bucket", defaultThresholdBytes)
+	workerOptions := worker.Options{
+		DataConverter: dataConverter,
+	}
+	env.SetWorkerOptions(workerOptions)
+
+	var activityResult S3LargePayload
+	env.SetOnActivityCompletedListener(func(activityInfo *activity.Info, result encoded.Value, err error) {
+		result.Get(&activityResult)
+	})
+
+	// Workflow generates its own payload internally, no input needed
+	env.ExecuteWorkflow(S3OffloadDataConverterWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, "batch-job-20240115-001", activityResult.JobID)
+	require.Equal(t, "s3-offload-worker-v1 (Processed)", activityResult.ProcessedBy)
+	require.Equal(t, 200, len(activityResult.DataPoints))
+}
+
+func Test_S3OffloadRoundTrip(t *testing.T) {
+	store := newMemoryBlobStore()
+	converter := NewS3OffloadDataConverter(store, "test-bucket", defaultThresholdBytes)
+
+	original := CreateS3LargePayload()
+	encoded, err := converter.ToData(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	// Large payload should be offloaded — the encoded form should be tiny
+	require.Equal(t, offloadPrefix, encoded[0], "expected offload prefix for large payload")
+	require.Less(t, len(encoded), 200, "Cadence history reference should be much smaller than full payload")
+
+	var decoded S3LargePayload
+	err = converter.FromData(encoded, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, original.JobID, decoded.JobID)
+	require.Equal(t, len(original.DataPoints), len(decoded.DataPoints))
+}
+
+func Test_S3InlineSmallPayload(t *testing.T) {
+	store := newMemoryBlobStore()
+	converter := NewS3OffloadDataConverter(store, "test-bucket", 100000) // very high threshold
+
+	original := CreateS3LargePayload()
+	enc, err := converter.ToData(original)
+	require.NoError(t, err)
+	require.Equal(t, inlinePrefix, enc[0], "expected inline prefix when payload is under threshold")
+
+	var decoded S3LargePayload
+	err = converter.FromData(enc, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, original.JobID, decoded.JobID)
+}

--- a/new_samples/data/worker.go
+++ b/new_samples/data/worker.go
@@ -143,7 +143,6 @@ func printEncryptionStats() {
 	fmt.Printf("Plaintext JSON size:  %d bytes\n", plaintextSize)
 	fmt.Printf("Ciphertext size:      %d bytes (overhead: %d bytes nonce+tag)\n", ciphertextSize, ciphertextSize-plaintextSize)
 	fmt.Printf("Ciphertext preview:   %s\n", preview)
-	fmt.Printf("WARNING: Using demo key. Set CADENCE_ENCRYPTION_KEY (64 hex chars) for production.\n")
 	fmt.Printf("Start workflow: cadence --domain %s workflow start --tl %s --workflow_type cadence_samples.EncryptionDataConverterWorkflow --et 60\n", Domain, TaskListEncryption)
 	fmt.Printf("====================================\n\n")
 }

--- a/new_samples/data/worker.go
+++ b/new_samples/data/worker.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/uber-go/tally"
 	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
@@ -154,7 +155,7 @@ func printS3OffloadStats() {
 	fmt.Printf("Stored in BlobStore:       %d bytes (%.2f KB)\n", jsonSize, float64(jsonSize)/1024.0)
 	fmt.Printf("Stored in Cadence history: %d bytes (claim-check reference only)\n", cadenceBytes)
 	fmt.Printf("Reduction in Cadence:      %.1f%%\n", 100.0*(1.0-float64(cadenceBytes)/float64(jsonSize)))
-	fmt.Printf("BlobStore location:        %s/cadence-samples-data-s3/\n", "os.TempDir()")
+	fmt.Printf("BlobStore location:        %s/cadence-samples-data-s3/\n", os.TempDir())
 	fmt.Printf("Start workflow: cadence --domain %s workflow start --tl %s --workflow_type cadence_samples.S3OffloadDataConverterWorkflow --et 60\n", Domain, TaskListS3)
 	fmt.Printf("=====================================\n\n")
 }

--- a/new_samples/data/worker.go
+++ b/new_samples/data/worker.go
@@ -1,5 +1,5 @@
 // Custom worker.go for Data samples - NOT generated
-// This sample requires a custom DataConverter in worker options
+// This sample requires custom DataConverters in worker options, one per sample.
 
 package main
 
@@ -24,45 +24,86 @@ import (
 const (
 	HostPort       = "127.0.0.1:7833"
 	Domain         = "cadence-samples"
-	TaskListName   = "cadence-samples-worker"
 	ClientName     = "cadence-samples-worker"
 	CadenceService = "cadence-frontend"
+
+	// Each sample uses its own task list so it can have its own DataConverter.
+	TaskListCompression = "cadence-samples-data-compression"
+	TaskListEncryption  = "cadence-samples-data-encryption"
+	TaskListS3          = "cadence-samples-data-s3"
 )
 
-// StartWorker creates and starts a Cadence worker with custom DataConverter.
+// StartWorker starts one worker per DataConverter sample and prints startup stats for each.
 func StartWorker() {
-	logger, cadenceClient := BuildLogger(), BuildCadenceClient()
+	logger := BuildLogger()
+	cadenceClient := BuildCadenceClient()
 
-	// Create compressed JSON data converter
-	dataConverter := NewCompressedJSONDataConverter()
+	startCompressionWorker(logger, cadenceClient)
+	startEncryptionWorker(logger, cadenceClient)
+	startS3OffloadWorker(logger, cadenceClient)
 
-	// Show compression statistics on startup
 	printCompressionStats()
-
-	workerOptions := worker.Options{
-		Logger:        logger,
-		MetricsScope:  tally.NewTestScope(TaskListName, nil),
-		DataConverter: dataConverter, // Custom DataConverter for compression
-	}
-
-	w := worker.New(
-		cadenceClient,
-		Domain,
-		TaskListName,
-		workerOptions)
-
-	// Register workflow and activity
-	w.RegisterWorkflowWithOptions(LargeDataConverterWorkflow, workflow.RegisterOptions{Name: "cadence_samples.LargeDataConverterWorkflow"})
-	w.RegisterActivityWithOptions(LargeDataConverterActivity, activity.RegisterOptions{Name: "cadence_samples.LargeDataConverterActivity"})
-
-	err := w.Start()
-	if err != nil {
-		panic("Failed to start worker: " + err.Error())
-	}
-	logger.Info("Started Worker.", zap.String("worker", TaskListName))
+	printEncryptionStats()
+	printS3OffloadStats()
 }
 
-// printCompressionStats displays compression statistics for the sample payload
+func startCompressionWorker(logger *zap.Logger, cadenceClient workflowserviceclient.Interface) {
+	dataConverter := NewCompressedJSONDataConverter()
+	workerOptions := worker.Options{
+		Logger:        logger,
+		MetricsScope:  tally.NewTestScope(TaskListCompression, nil),
+		DataConverter: dataConverter,
+	}
+
+	w := worker.New(cadenceClient, Domain, TaskListCompression, workerOptions)
+	w.RegisterWorkflowWithOptions(CompressionDataConverterWorkflow, workflow.RegisterOptions{Name: "cadence_samples.CompressionDataConverterWorkflow"})
+	w.RegisterActivityWithOptions(CompressionDataConverterActivity, activity.RegisterOptions{Name: "cadence_samples.CompressionDataConverterActivity"})
+
+	if err := w.Start(); err != nil {
+		panic("Failed to start compression worker: " + err.Error())
+	}
+	logger.Info("Started compression worker", zap.String("task_list", TaskListCompression))
+}
+
+func startEncryptionWorker(logger *zap.Logger, cadenceClient workflowserviceclient.Interface) {
+	key := LoadEncryptionKey()
+	dataConverter := NewEncryptedJSONDataConverter(key)
+	workerOptions := worker.Options{
+		Logger:        logger,
+		MetricsScope:  tally.NewTestScope(TaskListEncryption, nil),
+		DataConverter: dataConverter,
+	}
+
+	w := worker.New(cadenceClient, Domain, TaskListEncryption, workerOptions)
+	w.RegisterWorkflowWithOptions(EncryptionDataConverterWorkflow, workflow.RegisterOptions{Name: "cadence_samples.EncryptionDataConverterWorkflow"})
+	w.RegisterActivityWithOptions(EncryptionDataConverterActivity, activity.RegisterOptions{Name: "cadence_samples.EncryptionDataConverterActivity"})
+
+	if err := w.Start(); err != nil {
+		panic("Failed to start encryption worker: " + err.Error())
+	}
+	logger.Info("Started encryption worker", zap.String("task_list", TaskListEncryption))
+}
+
+func startS3OffloadWorker(logger *zap.Logger, cadenceClient workflowserviceclient.Interface) {
+	store := NewLocalFSBlobStore()
+	dataConverter := NewS3OffloadDataConverter(store, "cadence-samples-data-s3", defaultThresholdBytes)
+	workerOptions := worker.Options{
+		Logger:        logger,
+		MetricsScope:  tally.NewTestScope(TaskListS3, nil),
+		DataConverter: dataConverter,
+	}
+
+	w := worker.New(cadenceClient, Domain, TaskListS3, workerOptions)
+	w.RegisterWorkflowWithOptions(S3OffloadDataConverterWorkflow, workflow.RegisterOptions{Name: "cadence_samples.S3OffloadDataConverterWorkflow"})
+	w.RegisterActivityWithOptions(S3OffloadDataConverterActivity, activity.RegisterOptions{Name: "cadence_samples.S3OffloadDataConverterActivity"})
+
+	if err := w.Start(); err != nil {
+		panic("Failed to start S3 offload worker: " + err.Error())
+	}
+	logger.Info("Started S3 offload worker", zap.String("task_list", TaskListS3))
+}
+
+// printCompressionStats displays gzip compression statistics for the sample payload.
 func printCompressionStats() {
 	largePayload := CreateLargePayload()
 	originalSize, compressedSize, compressionPercentage, err := GetPayloadSizeInfo(largePayload, NewCompressedJSONDataConverter())
@@ -71,12 +112,51 @@ func printCompressionStats() {
 		return
 	}
 
-	fmt.Printf("\n=== Compression Statistics ===\n")
-	fmt.Printf("Original JSON size: %d bytes (%.2f KB)\n", originalSize, float64(originalSize)/1024.0)
-	fmt.Printf("Compressed size: %d bytes (%.2f KB)\n", compressedSize, float64(compressedSize)/1024.0)
-	fmt.Printf("Compression ratio: %.2f%% reduction\n", compressionPercentage)
-	fmt.Printf("Space saved: %d bytes (%.2f KB)\n", originalSize-compressedSize, float64(originalSize-compressedSize)/1024.0)
-	fmt.Printf("==============================\n\n")
+	fmt.Printf("\n=== Compression Sample Statistics ===\n")
+	fmt.Printf("Original JSON size:  %d bytes (%.2f KB)\n", originalSize, float64(originalSize)/1024.0)
+	fmt.Printf("Compressed size:     %d bytes (%.2f KB)\n", compressedSize, float64(compressedSize)/1024.0)
+	fmt.Printf("Compression ratio:   %.2f%% reduction\n", compressionPercentage)
+	fmt.Printf("Space saved:         %d bytes (%.2f KB)\n", originalSize-compressedSize, float64(originalSize-compressedSize)/1024.0)
+	fmt.Printf("Start workflow: cadence --domain %s workflow start --tl %s --workflow_type cadence_samples.CompressionDataConverterWorkflow --et 60\n", Domain, TaskListCompression)
+	fmt.Printf("=====================================\n\n")
+}
+
+// printEncryptionStats displays AES-256-GCM encryption statistics for the sample record.
+func printEncryptionStats() {
+	record := CreateSensitiveCustomerRecord()
+	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	plaintextSize, ciphertextSize, preview, err := GetEncryptionSizeInfo(record, converter)
+	if err != nil {
+		fmt.Printf("Error calculating encryption stats: %v\n", err)
+		return
+	}
+
+	fmt.Printf("\n=== Encryption Sample Statistics ===\n")
+	fmt.Printf("Plaintext JSON size:  %d bytes\n", plaintextSize)
+	fmt.Printf("Ciphertext size:      %d bytes (overhead: %d bytes nonce+tag)\n", ciphertextSize, ciphertextSize-plaintextSize)
+	fmt.Printf("Ciphertext preview:   %s\n", preview)
+	fmt.Printf("WARNING: Using demo key. Set CADENCE_ENCRYPTION_KEY (64 hex chars) for production.\n")
+	fmt.Printf("Start workflow: cadence --domain %s workflow start --tl %s --workflow_type cadence_samples.EncryptionDataConverterWorkflow --et 60\n", Domain, TaskListEncryption)
+	fmt.Printf("====================================\n\n")
+}
+
+// printS3OffloadStats displays claim-check offload statistics for the sample payload.
+func printS3OffloadStats() {
+	payload := CreateS3LargePayload()
+	jsonSize, cadenceBytes, err := GetS3OffloadSizeInfo(payload, defaultThresholdBytes)
+	if err != nil {
+		fmt.Printf("Error calculating S3 offload stats: %v\n", err)
+		return
+	}
+
+	fmt.Printf("\n=== S3 Offload Sample Statistics ===\n")
+	fmt.Printf("Full payload JSON size:    %d bytes (%.2f KB)\n", jsonSize, float64(jsonSize)/1024.0)
+	fmt.Printf("Stored in BlobStore:       %d bytes (%.2f KB)\n", jsonSize, float64(jsonSize)/1024.0)
+	fmt.Printf("Stored in Cadence history: %d bytes (claim-check reference only)\n", cadenceBytes)
+	fmt.Printf("Reduction in Cadence:      %.1f%%\n", 100.0*(1.0-float64(cadenceBytes)/float64(jsonSize)))
+	fmt.Printf("BlobStore location:        %s/cadence-samples-data-s3/\n", "os.TempDir()")
+	fmt.Printf("Start workflow: cadence --domain %s workflow start --tl %s --workflow_type cadence_samples.S3OffloadDataConverterWorkflow --et 60\n", Domain, TaskListS3)
+	fmt.Printf("=====================================\n\n")
 }
 
 func BuildCadenceClient(dialOptions ...grpc.DialOption) workflowserviceclient.Interface {

--- a/new_samples/data/worker.go
+++ b/new_samples/data/worker.go
@@ -68,7 +68,10 @@ func startCompressionWorker(logger *zap.Logger, cadenceClient workflowservicecli
 
 func startEncryptionWorker(logger *zap.Logger, cadenceClient workflowserviceclient.Interface) {
 	key := LoadEncryptionKey()
-	dataConverter := NewEncryptedJSONDataConverter(key)
+	dataConverter, err := NewEncryptedJSONDataConverter(key)
+	if err != nil {
+		panic("Failed to create encryption data converter: " + err.Error())
+	}
 	workerOptions := worker.Options{
 		Logger:        logger,
 		MetricsScope:  tally.NewTestScope(TaskListEncryption, nil),
@@ -125,7 +128,11 @@ func printCompressionStats() {
 // printEncryptionStats displays AES-256-GCM encryption statistics for the sample record.
 func printEncryptionStats() {
 	record := CreateSensitiveCustomerRecord()
-	converter := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	converter, err := NewEncryptedJSONDataConverter(demoEncryptionKey)
+	if err != nil {
+		fmt.Printf("Error creating encryption converter for stats: %v\n", err)
+		return
+	}
 	plaintextSize, ciphertextSize, preview, err := GetEncryptionSizeInfo(record, converter)
 	if err != nil {
 		fmt.Printf("Error calculating encryption stats: %v\n", err)


### PR DESCRIPTION


**Which sample(s) or area?**

- `new_samples/data` (workflow code, hand-written `worker.go`, generator)
- `new_samples/README.md` (Available Samples table).

**What changed?**

- Renamed the existing compression sample symbols `LargeDataConverter*` → `CompressionDataConverter*` and the file `dataconverter_workflow.go` → `compressed_dataconverter_workflow.go` so all three samples follow the same naming scheme.
- Added `encrypted_dataconverter_workflow.go` + test: AES-256-GCM `DataConverter` over JSON with a random 12-byte nonce per payload, a `SensitiveCustomerRecord` (PII/PHI) sample payload, and `LoadEncryptionKey()` that reads `CADENCE_ENCRYPTION_KEY` (hex) and falls back to a clearly-marked demo key.
- Added `s3_dataconverter_workflow.go` + test: a claim-check `DataConverter` that offloads payloads above a configurable threshold to a `BlobStore`, storing only a small reference in Cadence history. Ships with a zero-config `localFSBlobStore` and a fully-commented `s3BlobStore` stub showing the AWS SDK calls a user would add.
- Rewrote `worker.go` to start three concurrent workers (one per sample) on dedicated task lists `cadence-samples-data-compression`, `cadence-samples-data-encryption`, `cadence-samples-data-s3`, each with its own `DataConverter`, plus three startup statistics banners.
- Updated `generator/generate.go` to list all six functions and to skip `GenerateWorker()` so the hand-written `worker.go` is not clobbered on regeneration.
- Restructured `generator/README_specific.md` (and regenerated `README.md` + `main.go`) to document all three samples side-by-side, including CLI commands per task list, encryption key guidance, S3 swap-in instructions, and a "when to use which" comparison table.
- Added a `data/` row to the Available Samples table in `new_samples/README.md`.

**Why?**

The existing sample only showed compression, but `DataConverter` is also the natural place to add encryption (for PII/PHI) and external offload (to work around Cadence's payload size limits). Showing all three patterns in one folder lets readers compare them and copy the one they need. Each sample runs on its own task list with its own converter, the way they're actually deployed.

**How did you test it?**

```bash
# Build and run all unit tests for the data samples (1 compression + 3 encryption + 3 S3 = 7 tests)
go build ./new_samples/data/...
go test ./new_samples/data/... -v -timeout 60s

# Smoke test: bring up Cadence locally 
# then start the worker and three workflows
cd new_samples/data && go run .
# In another shell:
cadence --domain cadence-samples workflow start \
  --tl cadence-samples-data-compression \
  --workflow_type cadence_samples.CompressionDataConverterWorkflow --et 60
cadence --domain cadence-samples workflow start \
  --tl cadence-samples-data-encryption \
  --workflow_type cadence_samples.EncryptionDataConverterWorkflow --et 60
cadence --domain cadence-samples workflow start \
  --tl cadence-samples-data-s3 \
  --workflow_type cadence_samples.S3OffloadDataConverterWorkflow --et 60
```

**Potential risks**

- Renaming `LargeDataConverterWorkflow` → `CompressionDataConverterWorkflow` (and the activity) is a breaking change for anyone who has copied the previous workflow type name into scripts. This is a samples repo so the gearing toward consistency was intentional.
- The encryption sample's hardcoded demo key is intentionally public so the sample runs zero-config; the worker prints a warning at startup and the README has a "DO NOT USE IN PRODUCTION" callout. Anyone copying the sample must set `CADENCE_ENCRYPTION_KEY` and load it from a real secrets manager.
- The S3 sample's default `localFSBlobStore` writes to `os.TempDir()` and never deletes; in production users should swap in `s3BlobStore` and rely on S3 lifecycle policies for cleanup. Documented in the README.
- No new dependencies were added to `go.mod`.

**Release notes**

New samples in `new_samples/data/`: AES-256-GCM encryption `DataConverter` and an S3 claim-check `DataConverter` (with a zero-config local-FS default and a commented real-S3 stub). The existing compression sample's workflow and activity were renamed from `LargeDataConverter*` to `CompressionDataConverter*` for consistency.

**Documentation Changes**

- Updated `new_samples/data/generator/README_specific.md` to document all three samples (intro, per-sample sections with CLI commands, encryption key guidance, S3 swap-in steps, and a "when to use which" comparison table).
- Regenerated `new_samples/data/README.md` and `new_samples/data/main.go` via the sample generator.
- Added `data/` row to the Available Samples table in `new_samples/README.md`.
- No `cadence` or `cadence-docs` link updates required. Though the data conversion doc will be update once this and the java-samples equivalent are merged. 
