### PR TITLE
fix: error if domain does not exist - sample_helper

### DIFF
--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -159,7 +159,7 @@ func (h *SampleHelper) SetupServiceConfig() {
 	domainClient, _ := h.Builder.BuildCadenceDomainClient()
 	_, err = domainClient.Describe(context.Background(), h.Config.DomainName)
 	if err != nil {
-		logger.Info("Domain doesn't exist", zap.String("Domain", h.Config.DomainName), zap.Error(err))
+		logger.Error("Domain doesn't exist", zap.String("Domain", h.Config.DomainName), zap.Error(err))
 	} else {
 		logger.Info("Domain successfully registered.", zap.String("Domain", h.Config.DomainName))
 	}

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -159,7 +159,7 @@ func (h *SampleHelper) SetupServiceConfig() {
 	domainClient, _ := h.Builder.BuildCadenceDomainClient()
 	_, err = domainClient.Describe(context.Background(), h.Config.DomainName)
 	if err != nil {
-		logger.Error("Domain doesn't exist", zap.String("Domain", h.Config.DomainName), zap.Error(err))
+		logger.Fatal("Domain doesn't exist", zap.String("Domain", h.Config.DomainName), zap.Error(err))
 	} else {
 		logger.Info("Domain successfully registered.", zap.String("Domain", h.Config.DomainName))
 	}


### PR DESCRIPTION
<!-- For guidance on each section, see the PR guidance doc:
     https://github.com/cadence-workflow/cadence-samples/blob/master/.github/pull_request_guidance.md -->
**Which sample(s) or area?**
sample_helper

**What changed?**
Add early error if domain does not exist.

**Why?**
If domain does not exist, the sample will fail. Add early error so that the user knows that the issue is that the domain does not exist.

**How did you test it?**
No tests exist

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
