### PR TITLE
fix: Restore query samples

### DIFF
--- a/new_samples/query/README.md
+++ b/new_samples/query/README.md
@@ -14,7 +14,7 @@
 3. Register the `cadence-samples` domain:
 
 ```bash
-cadence --env development --domain cadence-samples domain register
+cadence --domain cadence-samples domain register
 ```
 
 Refresh the [domains page](http://localhost:8088/domains) from step 2 to verify `cadence-samples` is registered.

--- a/new_samples/query/generator/README.md
+++ b/new_samples/query/generator/README.md
@@ -21,3 +21,8 @@ In most cases, the workflow code (e.g. `workflow.go`) is the part that users car
 * When creating a new sample, follow the steps mentioned in the README file in the main samples folder.
 * To update the sample workflow code, edit the workflow file directly.
 * To update the worker, client, or other boilerplate logic, edit the generator file. If your change applies to all samples, update the common generator file inside the `template` folder. Edit the generator file in this folder only when the change should affect this sample alone.
+* When you are done run the following command in the generator folder
+
+```bash
+go run .
+```

--- a/new_samples/query/generator/generate.go
+++ b/new_samples/query/generator/generate.go
@@ -5,7 +5,7 @@ import "github.com/uber-common/cadence-samples/new_samples/template"
 func main() {
 	data := template.TemplateData{
 		SampleName: "Query",
-		Workflows:  []string{"QueryWorkflow"},
+		Workflows:  []string{"QueryWorkflow", "LunchVoteWorkflow", "MarkdownQueryWorkflow", "OrderFulfillmentWorkflow"},
 		Activities: []string{},
 	}
 

--- a/new_samples/query/lunch_vote_workflow.go
+++ b/new_samples/query/lunch_vote_workflow.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"text/template"
+	"time"
+
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+// lunchVoteFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type lunchVoteFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
+
+// LunchVoteWorkflow demonstrates using MarkDoc query responses for interactive voting.
+// Users can vote for lunch options via signal buttons rendered in the query response.
+func LunchVoteWorkflow(ctx workflow.Context) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("LunchVoteWorkflow started")
+
+	votes := []map[string]string{}
+
+	workflow.SetQueryHandler(ctx, "options", func() (lunchVoteFormattedResponse, error) {
+		logger := workflow.GetLogger(ctx)
+		logger.Info("Responding to 'options' query")
+
+		return makeLunchVoteResponse(ctx, votes), nil
+	})
+
+	votesChan := workflow.GetSignalChannel(ctx, "lunch_order")
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		for {
+			var vote map[string]string
+			votesChan.Receive(ctx, &vote)
+			votes = append(votes, vote)
+			logger.Info("Vote received", zap.Any("vote", vote))
+		}
+	})
+
+	// Voting period - reduced from 30 minutes for sample purposes
+	err := workflow.Sleep(ctx, 10*time.Minute)
+	if err != nil {
+		logger.Error("Sleep failed", zap.Error(err))
+		return err
+	}
+
+	logger.Info("LunchVoteWorkflow completed.", zap.Any("votes", votes))
+	return nil
+}
+
+// makeLunchVoteResponse creates the MarkDoc query response for lunch voting
+func makeLunchVoteResponse(ctx workflow.Context, votes []map[string]string) lunchVoteFormattedResponse {
+	type P map[string]interface{}
+
+	markdownTemplate, err := template.New("").Parse(`
+## Lunch Options
+
+We're voting on where to order lunch today. Select the option you want to vote for.
+
+---
+
+### Current Votes
+
+{{.voteTable}}
+
+### Menu Options
+
+{{.menuTable}}
+
+---
+
+### Cast Your Vote
+
+{% signal 
+	signalName="lunch_order" 
+	label="Farmhouse - Red Thai Curry"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="{{.workflowID}}"
+	runId="{{.runID}}"
+	input={"location":"Farmhouse","meal":"Red Thai Curry","requests":"spicy"}
+/%}
+{% signal 
+	signalName="lunch_order" 
+	label="Ethiopian Wat"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="{{.workflowID}}"
+	runId="{{.runID}}"
+	input={"location":"Ethiopian","meal":"Wat with Injera","requests":""}
+/%}
+{% signal 
+	signalName="lunch_order" 
+	label="Ler Ros - Tofu Bahn Mi"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="{{.workflowID}}"
+	runId="{{.runID}}"
+	input={"location":"Ler Ros","meal":"Tofu Bahn Mi","requests":""}
+/%}
+
+{% br /%}
+
+*Vote closes when workflow times out (10 minutes)*
+	`)
+	if err != nil {
+		panic("Failed to parse template: " + err.Error())
+	}
+
+	var markdown bytes.Buffer
+	err = markdownTemplate.Execute(&markdown, P{
+		"workflowID": workflow.GetInfo(ctx).WorkflowExecution.ID,
+		"runID":      workflow.GetInfo(ctx).WorkflowExecution.RunID,
+		"voteTable":  makeLunchVoteTable(votes),
+		"menuTable":  makeLunchMenu(),
+	})
+	if err != nil {
+		panic("Failed to execute template: " + err.Error())
+	}
+
+	return lunchVoteFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
+}
+
+// makeLunchVoteTable generates a markdown table of current votes
+func makeLunchVoteTable(votes []map[string]string) string {
+	if len(votes) == 0 {
+		return "| Location | Meal | Requests |\n|----------|------|----------|\n| *No votes yet* | | |\n"
+	}
+	table := "| Location | Meal | Requests |\n|----------|------|----------|\n"
+	for _, vote := range votes {
+		loc := vote["location"]
+		meal := vote["meal"]
+		requests := vote["requests"]
+		table += "| " + loc + " | " + meal + " | " + requests + " |\n"
+	}
+	return table
+}
+
+// makeLunchMenu generates a markdown table with menu options and images
+func makeLunchMenu() string {
+	options := []struct {
+		image string
+		desc  string
+	}{
+		{
+			image: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Red_roast_duck_curry.jpg/200px-Red_roast_duck_curry.jpg",
+			desc:  "**Farmhouse - Red Thai Curry**: A dish in Thai cuisine made from curry paste, coconut milk, meat, seafood, vegetables, and herbs.",
+		},
+		{
+			image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/B%C3%A1nh_m%C3%AC_th%E1%BB%8Bt_n%C6%B0%E1%BB%9Bng.png/200px-B%C3%A1nh_m%C3%AC_th%E1%BB%8Bt_n%C6%B0%E1%BB%9Bng.png",
+			desc:  "**Ler Ros - Tofu Bahn Mi**: A Vietnamese sandwich with a baguette filled with lemongrass tofu, vegetables, and fresh herbs.",
+		},
+		{
+			image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Ethiopian_wat.jpg/960px-Ethiopian_wat.jpg",
+			desc:  "**Ethiopian Wat**: A traditional Ethiopian stew made from spices, vegetables, and legumes, served with injera flatbread.",
+		},
+	}
+
+	table := "| Picture | Description |\n|---------|-------------|\n"
+	for _, option := range options {
+		table += "| ![food](" + option.image + ") | " + option.desc + " |\n"
+	}
+	table += "\n*(source: wikipedia)*"
+
+	return table
+}

--- a/new_samples/query/markdown_query.go
+++ b/new_samples/query/markdown_query.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"bytes"
+	"strconv"
+	"text/template"
+	"time"
+
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+const (
+	CompleteSignalChan = "complete"
+)
+
+// markdownFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type markdownFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
+
+func MarkdownQueryWorkflow(ctx workflow.Context) error {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute * 60,
+		StartToCloseTimeout:    time.Minute * 60,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+	logger := workflow.GetLogger(ctx)
+	logger.Info("MarkdownQueryWorkflow started")
+
+	workflow.SetQueryHandler(ctx, "Signal", func() (markdownFormattedResponse, error) {
+		logger := workflow.GetLogger(ctx)
+		logger.Info("Responding to 'Signal' query")
+
+		return makeMarkdownQueryResponse(ctx), nil
+	})
+
+	var complete bool
+	completeChan := workflow.GetSignalChannel(ctx, CompleteSignalChan)
+	for {
+		s := workflow.NewSelector(ctx)
+		s.AddReceive(completeChan, func(ch workflow.Channel, ok bool) {
+			if ok {
+				ch.Receive(ctx, &complete)
+			}
+			logger.Info("Signal input: " + strconv.FormatBool(complete))
+		})
+		s.Select(ctx)
+
+		var result string
+		err := workflow.ExecuteActivity(ctx, MarkdownQueryActivity, complete).Get(ctx, &result)
+		if err != nil {
+			return err
+		}
+		logger.Info("Activity result: " + result)
+		if complete {
+			return nil
+		}
+	}
+}
+
+func makeMarkdownQueryResponse(ctx workflow.Context) markdownFormattedResponse {
+	type P map[string]interface{}
+
+	markdownTemplate, err := template.New("").Parse(`
+	## Markdown Query Workflow
+	
+	You can use markdown as your query response, which also supports starting and signaling workflows.
+	
+	* Use the Complete button to complete this workflow.
+	* Use the Continue button just to send a signal to continue this workflow.
+	* Or you can use the "Start Another" button to start another workflow of this type.
+	
+	{% signal 
+		signalName="complete" 
+		label="Complete"
+		domain="cadence-samples"
+		cluster="cluster0"
+		workflowId="{{.workflowID}}"
+		runId="{{.runID}}"
+		input=true
+	/%}
+	{% signal
+		signalName="complete" 
+		label="Continue"
+		domain="cadence-samples"
+		cluster="cluster0"
+		workflowId="{{.workflowID}}"
+		runId="{{.runID}}"
+		input=false
+	/%}
+	{% start
+		workflowType="cadence_samples.MarkdownQueryWorkflow" 
+		label="Start Another"
+		domain="cadence-samples"
+		cluster="cluster0"
+		taskList="cadence-samples-worker"
+		workflowId="{{.newWorkflowID}}"
+		timeoutSeconds=60
+	/%}
+	
+	{% br /%} 
+	{% image src="https://cadenceworkflow.io/img/cadence-logo.svg" alt="Cadence Logo" height="100" /%}
+		`)
+	if err != nil {
+		panic("Failed to parse template: " + err.Error())
+	}
+
+	var markdown bytes.Buffer
+	err = markdownTemplate.Execute(&markdown, P{
+		"workflowID": workflow.GetInfo(ctx).WorkflowExecution.ID,
+		"runID":      workflow.GetInfo(ctx).WorkflowExecution.RunID,
+		"newWorkflowID": "markdown-" + strconv.FormatInt(time.Now().UnixNano()/1000000, 10),
+	})
+	if err != nil {
+		panic("Failed to execute template: " + err.Error())
+	}
+
+	return markdownFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
+}
+
+func MarkdownQueryActivity(ctx context.Context, complete bool) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("MarkdownQueryActivity started, a new signal has been received", zap.Bool("complete", complete))
+	if complete {
+		return "Workflow will complete now", nil
+	}
+	return "Workflow will continue to run", nil
+}

--- a/new_samples/query/order_fulfillment_workflow.go
+++ b/new_samples/query/order_fulfillment_workflow.go
@@ -1,0 +1,535 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+	"time"
+
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+)
+
+// orderDashboardFormattedResponse is the JSON shape Cadence Web expects for markdown query results (formattedData, text/markdown, data).
+type orderDashboardFormattedResponse struct {
+	CadenceResponseType string `json:"cadenceResponseType"`
+	Format              string `json:"format"`
+	Data                string `json:"data"`
+}
+
+// Order represents an e-commerce order being fulfilled
+type Order struct {
+	OrderID       string
+	CustomerName  string
+	CustomerEmail string
+	Items         []OrderItem
+	TotalAmount   float64
+	Status        string
+	TrackingNum   string
+	Carrier       string
+	RefundAmount  float64
+	RefundReason  string
+	CreatedAt     time.Time
+}
+
+// OrderItem represents a line item in an order
+type OrderItem struct {
+	Name     string
+	Quantity int
+	Price    float64
+}
+
+// ActionLogEntry represents an ops action taken on the order
+type ActionLogEntry struct {
+	Timestamp time.Time
+	Action    string
+	Operator  string
+	Details   string
+}
+
+// Order status constants
+const (
+	StatusPendingPayment  = "pending_payment"
+	StatusPaymentApproved = "payment_approved"
+	StatusReadyToShip     = "ready_to_ship"
+	StatusShipped         = "shipped"
+	StatusDelivered       = "delivered"
+	StatusCancelled       = "cancelled"
+	StatusRefunded        = "refunded"
+)
+
+// Signal payloads
+type RejectPaymentSignal struct {
+	Reason   string `json:"reason"`
+	Operator string `json:"operator"`
+}
+
+type ApprovePaymentSignal struct {
+	Operator string `json:"operator"`
+}
+
+type ShipOrderSignal struct {
+	TrackingNumber string `json:"trackingNumber"`
+	Carrier        string `json:"carrier"`
+	Operator       string `json:"operator"`
+}
+
+type RefundSignal struct {
+	Amount   float64 `json:"amount"`
+	Reason   string  `json:"reason"`
+	Operator string  `json:"operator"`
+}
+
+type CancelOrderSignal struct {
+	Reason   string `json:"reason"`
+	Operator string `json:"operator"`
+}
+
+type SimpleSignal struct {
+	Operator string `json:"operator"`
+}
+
+// OrderFulfillmentWorkflow demonstrates a state-driven MarkDoc UI for ops teams.
+// This workflow shows how Cadence Web queries can replace custom admin panels.
+func OrderFulfillmentWorkflow(ctx workflow.Context) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("OrderFulfillmentWorkflow started")
+
+	// Initialize sample order
+	order := Order{
+		OrderID:       "ORD-2024-001234",
+		CustomerName:  "Alice Johnson",
+		CustomerEmail: "alice.johnson@example.com",
+		Items: []OrderItem{
+			{Name: "Wireless Headphones", Quantity: 2, Price: 79.99},
+			{Name: "Phone Case", Quantity: 1, Price: 19.99},
+		},
+		TotalAmount: 179.97,
+		Status:      StatusPendingPayment,
+		CreatedAt:   workflow.Now(ctx),
+	}
+
+	// Action log for audit trail
+	actionLog := []ActionLogEntry{
+		{
+			Timestamp: workflow.Now(ctx),
+			Action:    "Order Created",
+			Operator:  "System",
+			Details:   fmt.Sprintf("Order %s created for %s", order.OrderID, order.CustomerName),
+		},
+	}
+
+	// Register query handler for the ops dashboard
+	workflow.SetQueryHandler(ctx, "dashboard", func() (orderDashboardFormattedResponse, error) {
+		logger.Info("Responding to 'dashboard' query")
+		return makeOrderDashboard(ctx, order, actionLog), nil
+	})
+
+	// Set up signal channels
+	approvePaymentChan := workflow.GetSignalChannel(ctx, "approve_payment")
+	rejectPaymentChan := workflow.GetSignalChannel(ctx, "reject_payment")
+	markReadyChan := workflow.GetSignalChannel(ctx, "mark_ready_to_ship")
+	shipOrderChan := workflow.GetSignalChannel(ctx, "ship_order")
+	refundChan := workflow.GetSignalChannel(ctx, "issue_refund")
+	cancelChan := workflow.GetSignalChannel(ctx, "cancel_order")
+	deliveredChan := workflow.GetSignalChannel(ctx, "mark_delivered")
+
+	// Main workflow loop - process signals until terminal state
+	for !isTerminalState(order.Status) {
+		selector := workflow.NewSelector(ctx)
+
+		selector.AddReceive(approvePaymentChan, func(ch workflow.Channel, ok bool) {
+			var signal ApprovePaymentSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusPendingPayment {
+				order.Status = StatusPaymentApproved
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Payment Approved",
+					Operator:  getOperator(signal.Operator),
+					Details:   fmt.Sprintf("Payment of $%.2f approved", order.TotalAmount),
+				})
+				logger.Info("Payment approved", zap.String("operator", signal.Operator))
+			}
+		})
+
+		selector.AddReceive(rejectPaymentChan, func(ch workflow.Channel, ok bool) {
+			var signal RejectPaymentSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusPendingPayment {
+				order.Status = StatusCancelled
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Payment Rejected",
+					Operator:  getOperator(signal.Operator),
+					Details:   fmt.Sprintf("Reason: %s", signal.Reason),
+				})
+				logger.Info("Payment rejected", zap.String("reason", signal.Reason))
+			}
+		})
+
+		selector.AddReceive(markReadyChan, func(ch workflow.Channel, ok bool) {
+			var signal SimpleSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusPaymentApproved {
+				order.Status = StatusReadyToShip
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Marked Ready to Ship",
+					Operator:  getOperator(signal.Operator),
+					Details:   "Order prepared and ready for shipping",
+				})
+				logger.Info("Order marked ready to ship")
+			}
+		})
+
+		selector.AddReceive(shipOrderChan, func(ch workflow.Channel, ok bool) {
+			var signal ShipOrderSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusReadyToShip {
+				order.Status = StatusShipped
+				order.TrackingNum = signal.TrackingNumber
+				order.Carrier = signal.Carrier
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Order Shipped",
+					Operator:  getOperator(signal.Operator),
+					Details:   fmt.Sprintf("Carrier: %s, Tracking: %s", signal.Carrier, signal.TrackingNumber),
+				})
+				logger.Info("Order shipped", zap.String("tracking", signal.TrackingNumber))
+			}
+		})
+
+		selector.AddReceive(refundChan, func(ch workflow.Channel, ok bool) {
+			var signal RefundSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusPaymentApproved {
+				order.Status = StatusRefunded
+				order.RefundAmount = signal.Amount
+				order.RefundReason = signal.Reason
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Refund Issued",
+					Operator:  getOperator(signal.Operator),
+					Details:   fmt.Sprintf("Amount: $%.2f, Reason: %s", signal.Amount, signal.Reason),
+				})
+				logger.Info("Refund issued", zap.Float64("amount", signal.Amount))
+			}
+		})
+
+		selector.AddReceive(cancelChan, func(ch workflow.Channel, ok bool) {
+			var signal CancelOrderSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusReadyToShip {
+				order.Status = StatusCancelled
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Order Cancelled",
+					Operator:  getOperator(signal.Operator),
+					Details:   fmt.Sprintf("Reason: %s", signal.Reason),
+				})
+				logger.Info("Order cancelled", zap.String("reason", signal.Reason))
+			}
+		})
+
+		selector.AddReceive(deliveredChan, func(ch workflow.Channel, ok bool) {
+			var signal SimpleSignal
+			ch.Receive(ctx, &signal)
+			if order.Status == StatusShipped {
+				order.Status = StatusDelivered
+				actionLog = append(actionLog, ActionLogEntry{
+					Timestamp: workflow.Now(ctx),
+					Action:    "Order Delivered",
+					Operator:  getOperator(signal.Operator),
+					Details:   "Package confirmed delivered to customer",
+				})
+				logger.Info("Order marked as delivered")
+			}
+		})
+
+		selector.Select(ctx)
+	}
+
+	logger.Info("OrderFulfillmentWorkflow completed", zap.String("finalStatus", order.Status))
+	return nil
+}
+
+func isTerminalState(status string) bool {
+	return status == StatusDelivered || status == StatusCancelled || status == StatusRefunded
+}
+
+func getOperator(operator string) string {
+	if operator == "" {
+		return "ops-user"
+	}
+	return operator
+}
+
+func makeOrderDashboard(ctx workflow.Context, order Order, actionLog []ActionLogEntry) orderDashboardFormattedResponse {
+	type P map[string]interface{}
+
+	markdownTemplate, err := template.New("").Parse(`
+## 🛒 Order Dashboard
+
+> **Your admin panel** - manage orders directly from Cadence Web.
+
+---
+
+### ⚡ Available Actions
+{{.actionButtons}}
+
+---
+
+### 📋 Order Details
+
+| Field | Value |
+|-------|-------|
+| **Order ID** | {{.orderID}} |
+| **Customer** | {{.customerName}} |
+| **Email** | {{.customerEmail}} |
+| **Created** | {{.createdAt}} |
+| **Status** | {{.statusBadge}} |
+{{if .trackingNum}} **Tracking: {{.carrier}} - {{.trackingNum}}** {{end}}
+{{if .refundAmount}}**Refund: ${{.refundAmount}}** {{end}}
+
+### 📦 Order Items
+
+| Item | Qty | Price | Subtotal |
+|------|-----|-------|----------|
+{{.itemsTable}}
+
+**Total: ${{.totalAmount}}**
+
+---
+
+### ⏱️ Action History
+
+| Timestamp | Action | Operator | Details |
+|-----------|--------|----------|---------|
+{{.actionHistory}}
+
+---
+
+*Click query "Run" button again to see updated status after taking an action.*
+	`)
+	if err != nil {
+		panic("Failed to parse template: " + err.Error())
+	}
+
+	var markdown bytes.Buffer
+	err = markdownTemplate.Execute(&markdown, P{
+		"orderID":       order.OrderID,
+		"customerName":  order.CustomerName,
+		"customerEmail": order.CustomerEmail,
+		"createdAt":     order.CreatedAt.Format("2006-01-02 15:04:05"),
+		"statusBadge":   getStatusBadge(order.Status),
+		"trackingNum":   order.TrackingNum,
+		"carrier":       order.Carrier,
+		"refundAmount":  fmt.Sprintf("%.2f", order.RefundAmount),
+		"refundReason":  order.RefundReason,
+		"totalAmount":   fmt.Sprintf("%.2f", order.TotalAmount),
+		"itemsTable":    makeItemsTable(order.Items),
+		"actionButtons": makeActionButtons(ctx, order),
+		"actionHistory": makeActionHistory(actionLog),
+	})
+	if err != nil {
+		panic("Failed to execute template: " + err.Error())
+	}
+
+	return orderDashboardFormattedResponse{
+		CadenceResponseType: "formattedData",
+		Format:              "text/markdown",
+		Data:                markdown.String(),
+	}
+}
+
+func getStatusBadge(status string) string {
+	badges := map[string]string{
+		StatusPendingPayment:  "🟡 **Pending Payment**",
+		StatusPaymentApproved: "🟢 **Payment Approved**",
+		StatusReadyToShip:     "📦 **Ready to Ship**",
+		StatusShipped:         "🚚 **Shipped**",
+		StatusDelivered:       "✅ **Delivered**",
+		StatusCancelled:       "❌ **Cancelled**",
+		StatusRefunded:        "💰 **Refunded**",
+	}
+	if badge, ok := badges[status]; ok {
+		return badge
+	}
+	return status
+}
+
+func makeItemsTable(items []OrderItem) string {
+	table := ""
+	for _, item := range items {
+		subtotal := float64(item.Quantity) * item.Price
+		table += fmt.Sprintf("| %s | %d | $%.2f | $%.2f |\n", item.Name, item.Quantity, item.Price, subtotal)
+	}
+	return table
+}
+
+func makeActionButtons(ctx workflow.Context, order Order) string {
+	workflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	runID := workflow.GetInfo(ctx).WorkflowExecution.RunID
+
+	var buttons string
+
+	switch order.Status {
+	case StatusPendingPayment:
+		buttons = fmt.Sprintf(`
+**Payment Review:**
+
+{%% signal 
+	signalName="approve_payment" 
+	label="✓ Approve Payment"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="reject_payment" 
+	label="✗ Reject: Policy Violation"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"reason":"Policy Violation","operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="reject_payment" 
+	label="✗ Reject: Fraud Suspected"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"reason":"Fraud Suspected","operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="reject_payment" 
+	label="✗ Reject: Customer Request"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"reason":"Customer Request","operator":"ops-user"}
+/%%}
+`, workflowID, runID, workflowID, runID, workflowID, runID, workflowID, runID)
+
+	case StatusPaymentApproved:
+		buttons = fmt.Sprintf(`
+**Fulfillment Actions:**
+
+{%% signal 
+	signalName="mark_ready_to_ship" 
+	label="📦 Mark Ready to Ship"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"operator":"ops-user"}
+/%%}
+
+**Refund Options:**
+
+{%% signal 
+	signalName="issue_refund" 
+	label="💰 Full Refund ($%.2f)"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"amount":%.2f,"reason":"Full refund requested","operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="issue_refund" 
+	label="💰 Partial Refund (50%%)"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"amount":%.2f,"reason":"Partial refund - customer goodwill","operator":"ops-user"}
+/%%}
+`, workflowID, runID, order.TotalAmount, workflowID, runID, order.TotalAmount, workflowID, runID, order.TotalAmount/2)
+
+	case StatusReadyToShip:
+		buttons = fmt.Sprintf(`
+**Shipping Options:**
+
+{%% signal 
+	signalName="ship_order" 
+	label="🚚 Ship via UPS"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"trackingNumber":"1Z999AA10123456784","carrier":"UPS","operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="ship_order" 
+	label="🚚 Ship via FedEx"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"trackingNumber":"794644790126","carrier":"FedEx","operator":"ops-user"}
+/%%}
+{%% signal 
+	signalName="ship_order" 
+	label="🚚 Ship via USPS"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"trackingNumber":"9400111899223456789012","carrier":"USPS","operator":"ops-user"}
+/%%}
+
+**Cancel Order:**
+
+{%% signal 
+	signalName="cancel_order" 
+	label="❌ Cancel Order"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"reason":"Cancelled before shipping","operator":"ops-user"}
+/%%}
+`, workflowID, runID, workflowID, runID, workflowID, runID, workflowID, runID)
+
+	case StatusShipped:
+		buttons = fmt.Sprintf(`
+**Delivery Confirmation:**
+
+{%% signal 
+	signalName="mark_delivered" 
+	label="✅ Mark as Delivered"
+	domain="cadence-samples"
+	cluster="cluster0"
+	workflowId="%s"
+	runId="%s"
+	input={"operator":"ops-user"}
+/%%}
+`, workflowID, runID)
+
+	default:
+		buttons = `
+*No actions available - order has been completed.*
+`
+	}
+
+	return buttons
+}
+
+func makeActionHistory(actionLog []ActionLogEntry) string {
+	history := ""
+	for _, entry := range actionLog {
+		history += fmt.Sprintf("| %s | %s | %s | %s |\n",
+			entry.Timestamp.Format("15:04:05"),
+			entry.Action,
+			entry.Operator,
+			entry.Details)
+	}
+	return history
+}

--- a/new_samples/query/worker.go
+++ b/new_samples/query/worker.go
@@ -44,6 +44,9 @@ func StartWorker() {
 		workerOptions)
 	// workflow registration
 	w.RegisterWorkflowWithOptions(QueryWorkflow, workflow.RegisterOptions{Name: "cadence_samples.QueryWorkflow"})
+	w.RegisterWorkflowWithOptions(LunchVoteWorkflow, workflow.RegisterOptions{Name: "cadence_samples.LunchVoteWorkflow"})
+	w.RegisterWorkflowWithOptions(MarkdownQueryWorkflow, workflow.RegisterOptions{Name: "cadence_samples.MarkdownQueryWorkflow"})
+	w.RegisterWorkflowWithOptions(OrderFulfillmentWorkflow, workflow.RegisterOptions{Name: "cadence_samples.OrderFulfillmentWorkflow"})
 
 	err := w.Start()
 	if err != nil {


### PR DESCRIPTION
**Which sample(s) or area?**
`new_samples/query` — Custom Workflow Controls samples

**What changed?**
Reinstated three files that were accidentally deleted in PR #130:
- `new_samples/query/lunch_vote_workflow.go`
- `new_samples/query/markdown_query.go`
- `new_samples/query/order_fulfillment_workflow.go`

**Why?**
These files were removed unintentionally as part of a batch migration PR. No code was changed — this is a straight restore from the commit immediately before the deletion.

**How did you test it?**
Verified file contents match the original via `git checkout 8b604c9^ -- <files>`. No logic changes were made.

**Potential risks**
None. Files are restored exactly as they were before deletion.

**Release notes**
N/A — restoring accidentally deleted sample files, no new functionality.

**Documentation Changes**
None.