### PR TITLE
fix(query): run generator to update README output

### DIFF
--- a/new_samples/query/README.md
+++ b/new_samples/query/README.md
@@ -14,7 +14,7 @@
 3. Register the `cadence-samples` domain:
 
 ```bash
-cadence --env development --domain cadence-samples domain register
+cadence --domain cadence-samples domain register
 ```
 
 Refresh the [domains page](http://localhost:8088/domains) from step 2 to verify `cadence-samples` is registered.

--- a/new_samples/query/generator/README.md
+++ b/new_samples/query/generator/README.md
@@ -21,3 +21,8 @@ In most cases, the workflow code (e.g. `workflow.go`) is the part that users car
 * When creating a new sample, follow the steps mentioned in the README file in the main samples folder.
 * To update the sample workflow code, edit the workflow file directly.
 * To update the worker, client, or other boilerplate logic, edit the generator file. If your change applies to all samples, update the common generator file inside the `template` folder. Edit the generator file in this folder only when the change should affect this sample alone.
+* When you are done run the following command in the generator folder
+
+```bash
+go run .
+```


### PR DESCRIPTION
**Which sample(s) or area?**
`new_samples/query`; query sample README

**What changed?**
Ran `go run generate.go` in `new_samples/query/generator` which updated the README; removes the redundant `--env development` flag from the domain registration command.

**Why?**
The generator output was stale. Picked up as part of restoring the deleted query workflow files in PR #165.

**How did you test it?**
Ran `go run generate.go` locally and committed the output.

**Potential risks**
None. Documentation-only change.

**Release notes**
N/A

**Documentation Changes**
`new_samples/query/README.md`;  `--env development` removed from the `cadence domain register` command.